### PR TITLE
Improve local-first Midea AC discovery and control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /env.json
 /node_modules/
 /.homeybuild/
+/scripts/verify-helpers.ts
 .DS_Store

--- a/.homeycompose/locales/en.json
+++ b/.homeycompose/locales/en.json
@@ -1,9 +1,34 @@
 {
 	"pair": {
 	  "error_adding_device": "Error while adding device",
+	  "discovery": {
+		"title": "Find Midea devices",
+		"searching": "Searching for devices...",
+		"done": "Search complete",
+		"error": "Error while searching for devices",
+      "empty": "Validated devices will appear here when ready.",
+      "deviceTitle": "Air conditioner",
+      "ipAddress": "IP",
+      "targetLabel": "Search another network",
+		"ready": "Ready:",
+		"validating": "Validating:",
+		"skipped": "Skipped:",
+		"searchTarget": "Search this network",
+		"addSelected": "Add selected",
+		"selectDevice": "Select at least one device",
+		"targetRequired": "Enter an IP address in the network to search",
+		"authenticating": "Authenticating selected devices...",
+		"authFailed": "Authentication failed. Continue with your MSmartHome credentials.",
+		"authErrorPrefix": "Last error:",
+		"retryCredentials": "Continue with credentials",
+		"useTokenKey": "Continue with token and key",
+		"needsAuth": "needs credentials or token",
+		"alreadyPaired": "already paired",
+		"useCredentialsOrToken": "Use token or credentials"
+	  },
 	  "token_and_key": {
 		"title": "Enter token and key of the device",
-		"message": "If the token and key of the device are known, values can be entered here. they can be entered manually or automatically retrieved from the cloud in the next screen (leave fields empty and press continue).",
+		"message": "If automatic authentication fails and the token and key of the device are known, values can be entered here.",
 		"tokenLabel": "Token",
 		"keyLabel": "Key",
 		"ipAdressLabel": "IP Address"

--- a/.homeycompose/locales/nl.json
+++ b/.homeycompose/locales/nl.json
@@ -1,9 +1,34 @@
 {
 	"pair": {
 	  "error_adding_device": "Fout bij het toevoegen van een device",
+	  "discovery": {
+		"title": "Midea-apparaten zoeken",
+		"searching": "Apparaten zoeken...",
+		"done": "Zoeken voltooid",
+		"error": "Fout bij het zoeken naar apparaten",
+      "empty": "Gevalideerde apparaten verschijnen hier zodra ze klaar zijn.",
+      "deviceTitle": "Airconditioner",
+      "ipAddress": "IP",
+      "targetLabel": "Zoek een ander netwerk",
+		"ready": "Klaar:",
+		"validating": "Valideren:",
+		"skipped": "Overgeslagen:",
+		"searchTarget": "Zoek dit netwerk",
+		"addSelected": "Geselecteerde toevoegen",
+		"selectDevice": "Selecteer minimaal een apparaat",
+		"targetRequired": "Voer een IP-adres in het netwerk in",
+		"authenticating": "Geselecteerde apparaten authenticeren...",
+		"authFailed": "Authenticatie mislukt. Ga verder met uw MSmartHome-inloggegevens.",
+		"authErrorPrefix": "Laatste fout:",
+		"retryCredentials": "Doorgaan met inloggegevens",
+		"useTokenKey": "Doorgaan met token en key",
+		"needsAuth": "inloggegevens of token nodig",
+		"alreadyPaired": "al gekoppeld",
+		"useCredentialsOrToken": "Gebruik token of inloggegevens"
+	  },
 	  "token_and_key": {
 		"title": "Voer de token en de key van het device in",
-		"message": "Als de token en de key van het apparaat bekend zijn, kunnen hier waarden worden ingevoerd. Deze kunnen handmatig worden ingevoerd of automatisch worden opgehaald uit de cloud in het volgende scherm (velden leeg laten en op Doorgaan drukken).",
+		"message": "Als automatische authenticatie mislukt en de token en key van het apparaat bekend zijn, kunnen deze hier worden ingevoerd.",
 		"tokenLabel": "Token",
 		"keyLabel": "Key",
 		"ipAdressLabel": "IP Adres"

--- a/app.json
+++ b/app.json
@@ -786,6 +786,7 @@
         "thermostat_mode",
         "target_temperature",
         "measure_temperature",
+        "measure_temperature.inside",
         "measure_temperature.outside",
         "thermostat_boost",
         "thermostat_fan_speed",
@@ -797,9 +798,15 @@
         "target_temperature": {
           "min": 16,
           "max": 30,
-          "step": 1
+          "step": 0.5
         },
         "measure_temperature": {
+          "title": {
+            "en": "Current temperature",
+            "nl": "Huidige temperatuur"
+          }
+        },
+        "measure_temperature.inside": {
           "title": {
             "en": "Inside temperature",
             "nl": "Binnentemperatuur"
@@ -820,13 +827,9 @@
       ],
       "pair": [
         {
-          "id": "list_devices",
-          "template": "list_devices",
-          "options": {
-            "singular": true
-          },
+          "id": "discovery",
           "navigation": {
-            "next": "token_and_key"
+            "next": "add_devices"
           }
         },
         {

--- a/drivers/airco/capabilities.ts
+++ b/drivers/airco/capabilities.ts
@@ -1,0 +1,296 @@
+'use strict';
+
+import { DeviceCapabilities, DeviceState } from 'midea-msmarthome-ac-euosk105';
+
+const OPERATIONAL_MODE_AUTO = 1;
+const OPERATIONAL_MODE_COOL = 2;
+const OPERATIONAL_MODE_DRY = 3;
+const OPERATIONAL_MODE_HEAT = 4;
+const OPERATIONAL_MODE_FAN = 5;
+const FAN_SPEED_SILENT = 20;
+const FAN_SPEED_LOW = 40;
+const FAN_SPEED_MEDIUM = 60;
+const FAN_SPEED_HIGH = 80;
+const FAN_SPEED_FULL = 100;
+const FAN_SPEED_AUTO = 102;
+const FAN_SPEED_FIXED = 101;
+const SWING_MODE_OFF = 0;
+const SWING_MODE_VERTICAL = 12;
+const SWING_MODE_HORIZONTAL = 3;
+const SWING_MODE_BOTH = 15;
+const DEFAULT_MIN_TARGET_TEMPERATURE = 16;
+const DEFAULT_MAX_TARGET_TEMPERATURE = 30;
+const FAHRENHEIT_TARGET_THRESHOLD = 45;
+const MIN_VALID_OUTDOOR_TEMPERATURE = -50;
+const MAX_VALID_OUTDOOR_TEMPERATURE = 60;
+
+export const SETTABLE_CAPABILITY_IDS = [
+  'onoff',
+  'target_temperature',
+  'thermostat_mode',
+  'thermostat_boost',
+  'thermostat_fan_speed',
+  'thermostat_swing_mode',
+  'thermostat_eco',
+  'thermostat_freeze_protection',
+];
+
+type CapabilityValue = {
+  id: string;
+  title: {
+    en: string;
+    nl: string;
+  };
+};
+
+type HomeyCapabilityValue = boolean | number | string | null;
+
+export type TargetTemperatureOptions = {
+  min: number;
+  max: number;
+  step: number;
+};
+
+export function getSupportedCapabilityIds(capabilities: DeviceCapabilities): string[] {
+  return [
+    'onoff',
+    'thermostat_mode',
+    'target_temperature',
+    'measure_temperature',
+    'measure_temperature.inside',
+    'measure_temperature.outside',
+    ...(capabilities.turboCool || capabilities.turboHeat ? ['thermostat_boost'] : []),
+    ...(capabilities.fanSpeedControl ? ['thermostat_fan_speed'] : []),
+    ...(capabilities.updownFan || capabilities.leftrightFan ? ['thermostat_swing_mode'] : []),
+    ...(capabilities.ecoMode || capabilities.specialEco ? ['thermostat_eco'] : []),
+    ...(capabilities.frostProtectionMode ? ['thermostat_freeze_protection'] : []),
+  ];
+}
+
+export function getTargetTemperatureOptions(capabilities: DeviceCapabilities): TargetTemperatureOptions {
+  const mins = [capabilities.minTempAuto, capabilities.minTempCool, capabilities.minTempHeat]
+    .filter((value) => Number.isFinite(value) && value > 0);
+  const maxes = [capabilities.maxTempAuto, capabilities.maxTempCool, capabilities.maxTempHeat]
+    .filter((value) => Number.isFinite(value) && value > 0);
+
+  return {
+    min: mins.length ? Math.min(...mins) : DEFAULT_MIN_TARGET_TEMPERATURE,
+    max: maxes.length ? Math.max(...maxes) : DEFAULT_MAX_TARGET_TEMPERATURE,
+    step: capabilities.decimals ? 0.5 : 1,
+  };
+}
+
+function roundToStep(value: number, step: number): number {
+  const rounded = Math.round(value / step) * step;
+  return Number(rounded.toFixed(step < 1 ? 1 : 0));
+}
+
+function isTargetTemperatureOptions(value: DeviceCapabilities | TargetTemperatureOptions): value is TargetTemperatureOptions {
+  return typeof (value as TargetTemperatureOptions).step === 'number';
+}
+
+export function normalizeTargetTemperatureWithOptions(value: number, options: TargetTemperatureOptions): number {
+  if (!Number.isFinite(value)) {
+    throw new Error(`Invalid target temperature: ${value}`);
+  }
+
+  const convertedValue = value >= FAHRENHEIT_TARGET_THRESHOLD
+    ? (value - 32) * (5 / 9)
+    : value;
+  const normalizedValue = roundToStep(convertedValue, options.step);
+
+  if (normalizedValue < options.min || normalizedValue > options.max) {
+    throw new Error(`Target temperature ${value} is outside supported range ${options.min}-${options.max}`);
+  }
+
+  return normalizedValue;
+}
+
+export function normalizeTargetTemperature(
+  value: number,
+  capabilities: DeviceCapabilities | TargetTemperatureOptions | null,
+): number {
+  let options: TargetTemperatureOptions;
+
+  if (!capabilities) {
+    options = {
+      min: DEFAULT_MIN_TARGET_TEMPERATURE,
+      max: DEFAULT_MAX_TARGET_TEMPERATURE,
+      step: 1,
+    };
+  } else if (isTargetTemperatureOptions(capabilities)) {
+    options = capabilities;
+  } else {
+    options = getTargetTemperatureOptions(capabilities);
+  }
+
+  return normalizeTargetTemperatureWithOptions(value, options);
+}
+
+export function normalizeOutdoorTemperature(value: number | null | undefined): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+
+  const temperature = Number(value);
+  if (temperature < MIN_VALID_OUTDOOR_TEMPERATURE || temperature > MAX_VALID_OUTDOOR_TEMPERATURE) {
+    return null;
+  }
+
+  return temperature;
+}
+
+function capabilityValue(id: string, en: string, nl: string): CapabilityValue {
+  return {
+    id,
+    title: { en, nl },
+  };
+}
+
+function getThermostatModeValues(capabilities: DeviceCapabilities): CapabilityValue[] {
+  const values = [
+    capabilityValue('off', 'Off', 'Uit'),
+  ];
+
+  if (capabilities.heatMode) {
+    values.push(capabilityValue('heat', 'Heat', 'Verwarmen'));
+  }
+  if (capabilities.coolMode) {
+    values.push(capabilityValue('cool', 'Cool', 'Koelen'));
+  }
+  if (capabilities.dryMode) {
+    values.push(capabilityValue('dry', 'Dry', 'Drogen'));
+  }
+  values.push(capabilityValue('fan', 'Fan', 'Ventilator'));
+  if (capabilities.autoMode) {
+    values.push(capabilityValue('auto', 'Automatic', 'Automatisch'));
+  }
+
+  return values;
+}
+
+function getSwingModeValues(capabilities: DeviceCapabilities): CapabilityValue[] {
+  const values = [
+    capabilityValue('off', 'Off', 'Uit'),
+  ];
+
+  if (capabilities.updownFan) {
+    values.push(capabilityValue('vertical', 'Vertical', 'Verticaal'));
+  }
+  if (capabilities.leftrightFan) {
+    values.push(capabilityValue('horizontal', 'Horizontal', 'Horizontaal'));
+  }
+  if (capabilities.updownFan && capabilities.leftrightFan) {
+    values.push(capabilityValue('both', 'Both', 'Beide'));
+  }
+
+  return values;
+}
+
+export function getCapabilityOptions(
+  capabilities: DeviceCapabilities,
+  _state?: DeviceState,
+): { [capabilityId: string]: object } {
+  return {
+    target_temperature: getTargetTemperatureOptions(capabilities),
+    measure_temperature: {
+      title: { en: 'Current temperature', nl: 'Huidige temperatuur' },
+    },
+    'measure_temperature.inside': {
+      title: { en: 'Inside temperature', nl: 'Binnentemperatuur' },
+    },
+    'measure_temperature.outside': {
+      title: { en: 'Outside temperature', nl: 'Buitentemperatuur' },
+    },
+    thermostat_mode: { values: getThermostatModeValues(capabilities) },
+    thermostat_swing_mode: { values: getSwingModeValues(capabilities) },
+  };
+}
+
+function setIfDefined(
+  values: { [capabilityId: string]: HomeyCapabilityValue },
+  capabilityId: string,
+  value: HomeyCapabilityValue | undefined,
+) {
+  if (value !== undefined) {
+    values[capabilityId] = value;
+  }
+}
+
+function getThermostatModeValue(state: DeviceState): string {
+  if (!state.powerOn) {
+    return 'off';
+  }
+
+  switch (state.operationalMode) {
+    case OPERATIONAL_MODE_AUTO: return 'auto';
+    case OPERATIONAL_MODE_COOL: return 'cool';
+    case OPERATIONAL_MODE_HEAT: return 'heat';
+    case OPERATIONAL_MODE_DRY: return 'dry';
+    case OPERATIONAL_MODE_FAN: return 'fan';
+    default: return 'off';
+  }
+}
+
+function getFanSpeedValue(state: DeviceState): string | undefined {
+  switch (Number(state.fanSpeed)) {
+    case FAN_SPEED_AUTO:
+    case FAN_SPEED_FIXED: return 'auto';
+    case FAN_SPEED_SILENT: return 'silent';
+    case FAN_SPEED_LOW: return 'low';
+    case FAN_SPEED_MEDIUM: return 'medium';
+    case FAN_SPEED_HIGH: return 'high';
+    case FAN_SPEED_FULL: return 'full';
+    default: return undefined;
+  }
+}
+
+function getSwingModeValue(state: DeviceState): string | undefined {
+  switch (Number(state.swingMode)) {
+    case SWING_MODE_OFF: return 'off';
+    case SWING_MODE_BOTH: return 'both';
+    case SWING_MODE_VERTICAL: return 'vertical';
+    case SWING_MODE_HORIZONTAL: return 'horizontal';
+    default: return undefined;
+  }
+}
+
+export function getCapabilityValues(state: DeviceState): { [capabilityId: string]: HomeyCapabilityValue } {
+  const values: { [capabilityId: string]: HomeyCapabilityValue } = {};
+  setIfDefined(values, 'onoff', typeof state.powerOn === 'boolean' ? state.powerOn : undefined);
+  setIfDefined(values, 'thermostat_mode', getThermostatModeValue(state));
+  setIfDefined(values, 'target_temperature', Number.isFinite(state.targetTemperature) ? state.targetTemperature : undefined);
+  if (state.operationalMode === OPERATIONAL_MODE_FAN && Number.isFinite(state.indoorTemperature)) {
+    values.target_temperature = state.indoorTemperature;
+  }
+  setIfDefined(values, 'measure_temperature', Number.isFinite(state.indoorTemperature) ? state.indoorTemperature : undefined);
+  setIfDefined(values, 'measure_temperature.inside', Number.isFinite(state.indoorTemperature) ? state.indoorTemperature : undefined);
+  setIfDefined(values, 'measure_temperature.outside', normalizeOutdoorTemperature(state.outdoorTemperature));
+  setIfDefined(values, 'thermostat_boost', typeof state.turboMode === 'boolean' ? state.turboMode : undefined);
+  setIfDefined(values, 'thermostat_fan_speed', getFanSpeedValue(state));
+  setIfDefined(values, 'thermostat_swing_mode', getSwingModeValue(state));
+  setIfDefined(values, 'thermostat_eco', typeof state.ecoMode === 'boolean' ? state.ecoMode : undefined);
+  setIfDefined(
+    values,
+    'thermostat_freeze_protection',
+    typeof state.freezeProtectionMode === 'boolean' ? state.freezeProtectionMode : undefined,
+  );
+
+  return values;
+}
+
+export function getInitialCapabilityValues(
+  state: DeviceState,
+  capabilityIds: string[],
+): { [capabilityId: string]: HomeyCapabilityValue } {
+  const supportedCapabilityIds = new Set(capabilityIds);
+
+  return Object.entries(getCapabilityValues(state))
+    .reduce<{ [capabilityId: string]: HomeyCapabilityValue }>((values, [capabilityId, value]) => {
+      if (supportedCapabilityIds.has(capabilityId)) {
+        values[capabilityId] = value;
+      }
+
+      return values;
+    }, {});
+}

--- a/drivers/airco/device.ts
+++ b/drivers/airco/device.ts
@@ -1,166 +1,289 @@
-import Homey from 'homey';
-import { Driver as MDriver, Device as MDevice, DeviceContext as MDeviceContext, GetStateCommand, DeviceState, LANSecurityContext, CloudSecurityContext,  SetStateCommand, _LOGGER } from 'midea-msmarthome-ac-euosk105';
-import { FAN_SPEED, OPERATIONAL_MODE, SWING_MODE } from 'midea-msmarthome-ac-euosk105/dist/DeviceState';
+'use strict';
 
-export class MideaDevice extends Homey.Device {
+/* eslint-disable import/extensions, import/no-unresolved, node/no-missing-import */
+import Homey from 'homey';
+import {
+  Driver as MDriver,
+  Device as MDevice,
+  DeviceContext as MDeviceContext,
+  DeviceState,
+  GetStateCommand,
+  LANSecurityContext,
+  SetStateCommand,
+  _LOGGER,
+} from 'midea-msmarthome-ac-euosk105';
+import { FAN_SPEED, OPERATIONAL_MODE, SWING_MODE } from 'midea-msmarthome-ac-euosk105/dist/DeviceState';
+import {
+  normalizeOutdoorTemperature,
+  normalizeTargetTemperature,
+  SETTABLE_CAPABILITY_IDS,
+  type TargetTemperatureOptions,
+} from './capabilities';
+
+const LAN_OPERATION_TIMEOUT_MS = 15000;
+const LAN_OPERATION_ATTEMPTS = 2;
+
+type CapabilityValue = boolean | number | string | null;
+type RediscoveryResult = {
+  host: string;
+  port: number;
+};
+
+type RediscoveryDriver = {
+  rediscoverMideaDevice?: (device: { id: number; host?: string }) => Promise<RediscoveryResult | null>;
+};
+
+class MideaDevice extends Homey.Device {
+
   public _device: MDevice;
-  private _intervalId: any;
-  private _updatingState: boolean = false;
+  private _pollTimerId: NodeJS.Timeout | null = null;
+  private _pollGeneration: number = 0;
   private _maximumFailureCount:number = 5;
   private _failureCount: number = 0;
-  
+  private _commandQueue: Promise<void> = Promise.resolve();
+  private _lastState: DeviceState | null = null;
+  private _registeredCapabilityListeners = new Set<string>();
+
   /**
    * onInit is called when the device is initialized.
    */
   async onInit() {
-    this.log('Midea AC [' + this.getName() + '] initializing ...');
+    this.log(`Midea AC [${this.getName()}] initializing ...`);
     this._failureCount = 0;
+    this._commandQueue = Promise.resolve();
+    this._stopPolling();
+    if (this._device) {
+      this._device.close();
+    }
+    const settings = this.getSettings();
+    this._maximumFailureCount = +settings.max_number_of_errors_before_device_unavailable;
 
     try {
-      const deviceContext: MDeviceContext = new MDeviceContext();
-      deviceContext.id = this.getData().id;
-      deviceContext.macAddress = this.getData().macAddress;
-      deviceContext.udpId = this.getData().udpId;
-      deviceContext.host = this.getStore().host;
-      deviceContext.port = this.getStore().port;
+      const store = this.getStore();
+      const deviceContext = this._createDeviceContext();
       this._device = new MDevice(deviceContext);
 
-      // RETRIEVE TOKEN AND KEY FROM USERNAME PASSWORD IF NOT ADDED DURING PAIRING
-      if (!this.getStore().token || !this.getStore().key) {
-        let cloudSecurityContext: CloudSecurityContext =  new CloudSecurityContext(this.getStore().username, this.getStore().password);
-        let lanSecurityContext: LANSecurityContext = await MDriver.retrieveTokenAndKeyFromCloud(this._device, cloudSecurityContext);
-        this.setStoreValue("token",  lanSecurityContext.token);
-        this.setStoreValue("key",  lanSecurityContext.key);
+      let { token } = store;
+      let { key } = store;
+      if (!token || !key) {
+        const lanSecurityContext: LANSecurityContext = await MDriver.retrieveTokenAndKeyFromCloud(this._device, null);
+        token = lanSecurityContext.token;
+        key = lanSecurityContext.key;
       }
-      await this._device.authenticate(new LANSecurityContext(this.getStore().token, this.getStore().key));
 
-      // REGISTER CAPABILITY LISTENERS
-      this.registerCapabilityListener("onoff", async (value, opts) => { return this.onCapability("onoff", value, opts); });
-      this.registerCapabilityListener("target_temperature", async (value, opts) => { return this.onCapability("target_temperature", value, opts); });
-      this.registerCapabilityListener("thermostat_mode", async (value, opts) => { return this.onCapability("thermostat_mode", value, opts); });
-      this.registerCapabilityListener("thermostat_boost", async (value, opts) => { return this.onCapability("thermostat_boost", value, opts); });
-      this.registerCapabilityListener("thermostat_fan_speed", async (value, opts) => { return this.onCapability("thermostat_fan_speed", value, opts); });
-      this.registerCapabilityListener("thermostat_swing_mode", async (value, opts) => { return this.onCapability("thermostat_swing_mode", value, opts); });
-      this.registerCapabilityListener("thermostat_eco", async (value, opts) => { return this.onCapability("thermostat_eco", value, opts); });
-      this.registerCapabilityListener("thermostat_freeze_protection", async (value, opts) => { return this.onCapability("thermostat_freeze_protection", value, opts); });
+      await this.setStoreValue('host', deviceContext.host);
+      await this.setStoreValue('port', deviceContext.port);
+      await this.setStoreValue('token', token);
+      await this.setStoreValue('key', key);
+
+      this._registerCapabilityListeners();
 
       // INITIALLY UPDATE STATE AND SET DEVICE TO AVAILABLE
       await this._refreshState();
-      this.setAvailable();       
+      await this.setAvailable();
 
       // INITIALIZE POLLING
-      const settings = this.getSettings();
-      this._maximumFailureCount = +settings.max_number_of_errors_before_device_unavailable;
       this._initializePolling(settings.polling_interval);
 
-      this.log('Midea AC [' + this.getName() + '] initialized successfully'); 
+      this.log(`Midea AC [${this.getName()}] initialized successfully`);
     } catch (err) {
-      this.error("Cannot initialize device[" + this.getName() + "]: " + (err instanceof Error ? err.message : JSON.stringify(err)));
-      this.setUnavailable("Cannot initialize device[" + this.getName() + "]: " + (err instanceof Error ? err.message : JSON.stringify(err)));
+      this.error(`Cannot initialize device[${this.getName()}]: ${err instanceof Error ? err.message : JSON.stringify(err)}`);
+      await this.setUnavailable(`Cannot initialize device[${this.getName()}]: ${err instanceof Error ? err.message : JSON.stringify(err)}`);
+      if (this._getStoredLanSecurityContext()) {
+        this._initializePolling(settings.polling_interval);
+      }
     }
   }
 
   private _initializePolling(pollingInterval: number) {
-    // CLEAR POLLING
-    if (this._intervalId) this.homey.clearInterval(this._intervalId);
+    this._stopPolling();
+    const generation = this._pollGeneration;
+    const pollingIntervalMs = pollingInterval * 1000;
 
-    // SET POLLER
-    this._intervalId = this.homey.setInterval(async () => {
+    const poll = async () => {
+      this._pollTimerId = null;
       try {
         await this._refreshState();
       } catch (err) {
-        this.homey.clearInterval(this._intervalId);
-        this.error("Error during polling: " + (err instanceof Error ? err.message : JSON.stringify(err)));
-        this.setUnavailable("Device [" + this.getName() + "] is unavailable; failure count: " + this._failureCount);
+        this.error(`Error during polling: ${err instanceof Error ? err.message : JSON.stringify(err)}`);
+        if (this.getAvailable()) {
+          await this.setUnavailable(`Device [${this.getName()}] is unavailable; failure count: ${this._failureCount}`);
+        }
       }
-    }, pollingInterval * 1000);
+
+      if (generation === this._pollGeneration) {
+        this._pollTimerId = this.homey.setTimeout(poll, pollingIntervalMs);
+      }
+    };
+
+    this._pollTimerId = this.homey.setTimeout(poll, pollingIntervalMs);
+  }
+
+  private _stopPolling() {
+    this._pollGeneration++;
+    if (this._pollTimerId) {
+      this.homey.clearTimeout(this._pollTimerId);
+      this._pollTimerId = null;
+    }
   }
 
   /**
    * _refreshState is called when the device state has to be updated.
    */
   private async _refreshState() {
-    if (this._updatingState) {
-      this.log("Skipping state refresh because another update is in progress");
-      return;
-    }
+    return this._runExclusive(() => this._refreshStateUnsafe());
+  }
 
+  private async _refreshStateUnsafe() {
     try {
-      // EXECUTE THE GETSTATECOMMAND TO RETREIVE THE STATE AND REFRESH HOMEY'S DEVICE STATE
-      const state: DeviceState = await new GetStateCommand(this._device).execute();
-      this._updateState(state);
-
-      // AT THS STAGE REFRESHING HAS BEEN SUCCESFUL, WHICH RESETS THE FAILURE COUNT
-      this._failureCount = 0;
+      await this._fetchAndApplyDeviceStateUnsafe('get state');
     } catch (err) {
       // AN ERROR HAS OCCURED; INCREASE FAILURE COUNT AND CHECK IF THE MAXIMUM NUMBER OF ERRORS HAS BEEN REACHED
-      // IF SO, STOP POLLING AND SET DEVICE UNAVAILABLE ELSE, LOG THE ERROR AND RETRY
-      this._failureCount++;   
-      this.error("Error during polling of device [" + this.getName() + "]; failure count = " + this._failureCount + " : " + (err instanceof Error ? err.message : JSON.stringify(err)));
+      // IF SO, MARK DEVICE UNAVAILABLE WHILE THE POLLER KEEPS TRYING TO RECOVER
+      this._failureCount++;
+      this.error(`Error during polling of device [${this.getName()}]; failure count = ${this._failureCount} : ${err instanceof Error ? err.message : JSON.stringify(err)}`);
       if (this._failureCount < this._maximumFailureCount) {
-        this.log("Retrying");
-      } else { 
-        throw new Error("Device [" + this.getName() + "] is failing multiple times; failure count: " + this._failureCount);
+        this.log('Retrying');
+      } else {
+        throw new Error(`Device [${this.getName()}] is failing multiple times; failure count: ${this._failureCount}`);
       }
     }
+  }
+
+  public async getCurrentDeviceState(): Promise<DeviceState> {
+    return this._runExclusive(() => this._fetchAndApplyDeviceStateUnsafe('get current device state'));
+  }
+
+  public async isBoostEnabled(): Promise<boolean> {
+    const state = await this.getCurrentDeviceState();
+    return state.turboMode;
+  }
+
+  public async isEcoEnabled(): Promise<boolean> {
+    const state = await this.getCurrentDeviceState();
+    return state.ecoMode;
+  }
+
+  public async isFreezeProtectionEnabled(): Promise<boolean> {
+    const state = await this.getCurrentDeviceState();
+    return state.freezeProtectionMode;
+  }
+
+  public async getFanSpeedValue(): Promise<string | null> {
+    const state = await this.getCurrentDeviceState();
+    switch (state.fanSpeed) {
+      case FAN_SPEED.AUTO: return 'auto';
+      case FAN_SPEED.FIXED: return 'auto';
+      case FAN_SPEED.SILENT: return 'silent';
+      case FAN_SPEED.LOW: return 'low';
+      case FAN_SPEED.MEDIUM: return 'medium';
+      case FAN_SPEED.HIGH: return 'high';
+      case FAN_SPEED.FULL: return 'full';
+      default: return null;
+    }
+  }
+
+  public async getSwingModeValue(): Promise<string | null> {
+    const state = await this.getCurrentDeviceState();
+    switch (state.swingMode) {
+      case SWING_MODE.OFF: return 'off';
+      case SWING_MODE.BOTH: return 'both';
+      case SWING_MODE.VERTICAL: return 'vertical';
+      case SWING_MODE.HORIZONTAL: return 'horizontal';
+      default: return null;
+    }
+  }
+
+  public async getThermostatModeValue(): Promise<string | null> {
+    const state = await this.getCurrentDeviceState();
+    if (!state.powerOn) {
+      return 'off';
+    }
+
+    switch (state.operationalMode) {
+      case OPERATIONAL_MODE.AUTO: return 'auto';
+      case OPERATIONAL_MODE.COOL: return 'cool';
+      case OPERATIONAL_MODE.HEAT: return 'heat';
+      case OPERATIONAL_MODE.DRY: return 'dry';
+      case OPERATIONAL_MODE.FAN: return 'fan';
+      default: return null;
+    }
+  }
+
+  private async _fetchAndApplyDeviceStateUnsafe(label: string): Promise<DeviceState> {
+    const state = await this._getFreshDeviceStateUnsafe(label);
+    await this._updateState(state);
+    await this._setLastSeenAtIfAvailable();
+
+    this._failureCount = 0;
+    if (!this.getAvailable()) {
+      await this.setAvailable();
+    }
+
+    return this._cloneDeviceState(state);
   }
 
   /**
    * _updateState is called when the device state has been retreived ia the local API and the Homey's device state needs to be updated.
    * @param {DeviceState} state The new state
    */
-  private _updateState(state: DeviceState) {
-    this.log("state = " + JSON.stringify(state) + ")");
-    this.setCapabilityValue("onoff", state.powerOn);
+  private async _updateState(state: DeviceState) {
+    this._lastState = this._cloneDeviceState(state);
+    this.log(`state = ${JSON.stringify(state)})`);
+    await this._setCapabilityValueIfAvailable('onoff', state.powerOn);
     if (state.powerOn) {
       switch (state.operationalMode) {
-        case OPERATIONAL_MODE.AUTO: this.setCapabilityValue("thermostat_mode", "auto"); break;
-        case OPERATIONAL_MODE.COOL: this.setCapabilityValue("thermostat_mode", "cool"); break;
-        case OPERATIONAL_MODE.HEAT: this.setCapabilityValue("thermostat_mode", "heat"); break;
-        case OPERATIONAL_MODE.DRY: this.setCapabilityValue("thermostat_mode", "dry"); break;
-        case OPERATIONAL_MODE.FAN: this.setCapabilityValue("thermostat_mode", "fan"); break;
+        case OPERATIONAL_MODE.AUTO: await this._setCapabilityValueIfAvailable('thermostat_mode', 'auto'); break;
+        case OPERATIONAL_MODE.COOL: await this._setCapabilityValueIfAvailable('thermostat_mode', 'cool'); break;
+        case OPERATIONAL_MODE.HEAT: await this._setCapabilityValueIfAvailable('thermostat_mode', 'heat'); break;
+        case OPERATIONAL_MODE.DRY: await this._setCapabilityValueIfAvailable('thermostat_mode', 'dry'); break;
+        case OPERATIONAL_MODE.FAN: await this._setCapabilityValueIfAvailable('thermostat_mode', 'fan'); break;
+        default: break;
       }
     } else {
-      this.setCapabilityValue("thermostat_mode", "off");
+      await this._setCapabilityValueIfAvailable('thermostat_mode', 'off');
     }
-    this.setCapabilityValue("thermostat_boost", state.turboMode);
+    await this._setCapabilityValueIfAvailable('thermostat_boost', state.turboMode);
 
-    this.setCapabilityValue("target_temperature", state.targetTemperature);
-    if (state.operationalMode == OPERATIONAL_MODE.FAN) {
-      this.setCapabilityValue("target_temperature", state.indoorTemperature);
+    await this._setCapabilityValueIfAvailable('target_temperature', state.targetTemperature);
+    if (state.operationalMode === OPERATIONAL_MODE.FAN) {
+      await this._setCapabilityValueIfAvailable('target_temperature', state.indoorTemperature);
     }
-    this.setCapabilityValue("measure_temperature", state.indoorTemperature);
+    await this._setCapabilityValueIfAvailable('measure_temperature', state.indoorTemperature);
+    await this._setCapabilityValueIfAvailable('measure_temperature.inside', state.indoorTemperature);
 
-    if (state.outdoorTemperature != null && state.outdoorTemperature < 60) {
-      this.setCapabilityValue("measure_temperature.outside", state.outdoorTemperature);
-    } else {
-      this.log("Ignoring invalid outdoor temperature:", state.outdoorTemperature);
+    const outdoorTemperature = normalizeOutdoorTemperature(state.outdoorTemperature);
+    await this._setCapabilityValueIfAvailable('measure_temperature.outside', outdoorTemperature);
+    if (outdoorTemperature == null) {
+      this.log('Ignoring invalid outdoor temperature:', state.outdoorTemperature);
     }
 
     switch (state.fanSpeed) {
-      case FAN_SPEED.AUTO: this.setCapabilityValue("thermostat_fan_speed", "auto"); break;
-      case FAN_SPEED.FIXED: this.setCapabilityValue("thermostat_fan_speed", "auto"); break;
-      case FAN_SPEED.SILENT: this.setCapabilityValue("thermostat_fan_speed", "silent"); break;
-      case FAN_SPEED.LOW: this.setCapabilityValue("thermostat_fan_speed", "low"); break;
-      case FAN_SPEED.MEDIUM: this.setCapabilityValue("thermostat_fan_speed", "medium"); break;
-      case FAN_SPEED.HIGH: this.setCapabilityValue("thermostat_fan_speed", "high"); break;
-      case FAN_SPEED.FULL: this.setCapabilityValue("thermostat_fan_speed", "full"); break;
+      case FAN_SPEED.AUTO: await this._setCapabilityValueIfAvailable('thermostat_fan_speed', 'auto'); break;
+      case FAN_SPEED.FIXED: await this._setCapabilityValueIfAvailable('thermostat_fan_speed', 'auto'); break;
+      case FAN_SPEED.SILENT: await this._setCapabilityValueIfAvailable('thermostat_fan_speed', 'silent'); break;
+      case FAN_SPEED.LOW: await this._setCapabilityValueIfAvailable('thermostat_fan_speed', 'low'); break;
+      case FAN_SPEED.MEDIUM: await this._setCapabilityValueIfAvailable('thermostat_fan_speed', 'medium'); break;
+      case FAN_SPEED.HIGH: await this._setCapabilityValueIfAvailable('thermostat_fan_speed', 'high'); break;
+      case FAN_SPEED.FULL: await this._setCapabilityValueIfAvailable('thermostat_fan_speed', 'full'); break;
+      default: break;
     }
     switch (state.swingMode) {
-      case SWING_MODE.OFF: this.setCapabilityValue("thermostat_swing_mode", "off"); break;
-      case SWING_MODE.BOTH: this.setCapabilityValue("thermostat_swing_mode", "both"); break;
-      case SWING_MODE.VERTICAL: this.setCapabilityValue("thermostat_swing_mode", "vertical"); break;
-      case SWING_MODE.HORIZONTAL: this.setCapabilityValue("thermostat_swing_mode", "horizontal"); break;
+      case SWING_MODE.OFF: await this._setCapabilityValueIfAvailable('thermostat_swing_mode', 'off'); break;
+      case SWING_MODE.BOTH: await this._setCapabilityValueIfAvailable('thermostat_swing_mode', 'both'); break;
+      case SWING_MODE.VERTICAL: await this._setCapabilityValueIfAvailable('thermostat_swing_mode', 'vertical'); break;
+      case SWING_MODE.HORIZONTAL: await this._setCapabilityValueIfAvailable('thermostat_swing_mode', 'horizontal'); break;
+      default: break;
     }
-    this.setCapabilityValue("thermostat_eco", state.ecoMode);
-    this.setCapabilityValue("thermostat_freeze_protection", state.freezeProtectionMode);
+    await this._setCapabilityValueIfAvailable('thermostat_eco', state.ecoMode);
+    await this._setCapabilityValueIfAvailable('thermostat_freeze_protection', state.freezeProtectionMode);
   }
 
   /**
    * onAdded is called when the user adds the device, called just after pairing.
    */
   async onAdded() {
-    this.log('Midea AC [' + this.getName() + '] has been added');
+    this.log(`Midea AC [${this.getName()}] has been added`);
   }
 
   /**
@@ -180,16 +303,15 @@ export class MideaDevice extends Homey.Device {
     newSettings: { [key: string]: boolean | string | number | undefined | null };
     changedKeys: string[];
   }): Promise<string | void> {
-
-    if (changedKeys.includes("polling_interval")) {
+    if (changedKeys.includes('polling_interval')) {
       this._initializePolling(+newSettings.polling_interval);
     }
-    if (changedKeys.includes("debug_level")) {
+    if (changedKeys.includes('debug_level')) {
       _LOGGER.level = newSettings.debug_level.toString();
     }
-    if (changedKeys.includes("max_number_of_errors_before_device_unavailable")) {
+    if (changedKeys.includes('max_number_of_errors_before_device_unavailable')) {
       this._maximumFailureCount = +newSettings.max_number_of_errors_before_device_unavailable;
-      this.onInit();
+      await this.onInit();
     }
   }
 
@@ -199,120 +321,368 @@ export class MideaDevice extends Homey.Device {
    * @param {string} name The new name
    */
   async onRenamed(name: string) {
-    this.log('Midea AC [' + this.getName() + '] was renamed to "' + name + '"');
+    this.log(`Midea AC [${this.getName()}] was renamed to "${name}"`);
   }
 
   /**
    * onDeleted is called when the user deleted the device.
    */
   async onDeleted() {
-    this.homey.clearInterval(this._intervalId);
-    this.log('Midea AC [' + this.getName() + '] has been deleted');
+    this._stopPolling();
+    if (this._device) {
+      this._device.close();
+    }
+    this.log(`Midea AC [${this.getName()}] has been deleted`);
   }
 
-  async onCapability(capability: string, value: any, opts: any) {
-    this.log("Device::onCapability(capability='" + capability + "', value='", value, "')");
-    try {
-      this._updatingState = true;
-      let state: DeviceState = await new GetStateCommand(this._device).execute();
-
-      switch (capability) {
-        case "onoff": state.powerOn = value; break;
-        case "target_temperature": state.targetTemperature = value; break;
-        case "thermostat_mode": {
-          switch (value) {
-            case "auto": state.powerOn = true; state.operationalMode = OPERATIONAL_MODE.AUTO; break;
-            case "cool": state.powerOn = true; state.operationalMode = OPERATIONAL_MODE.COOL; break;
-            case "heat": state.powerOn = true; state.operationalMode = OPERATIONAL_MODE.HEAT; break;
-            case "dry": state.powerOn = true; state.operationalMode = OPERATIONAL_MODE.DRY; break;
-            case "fan": state.powerOn = true; state.operationalMode = OPERATIONAL_MODE.FAN; break;
-            case "off": state.powerOn = false; break; /* this behaves exactly the same as the onoff button */
-            default:
-              this.log("Value '" + value + "' for capability 'thermostat_mode' does not exist");
-              break;
-          }
-          break;
-        }
-        case "thermostat_boost":  {
-          if (value) {
-            /* boost mode disables ECO and freeze protection */
-            this.setCapabilityValue("thermostat_eco", (state.ecoMode = false));
-            this.setCapabilityValue("thermostat_freeze_protection", (state.freezeProtectionMode = false));
-          }
-          state.turboMode = value; break; /* only available in thermostat_mode 'heat' or 'cool' */
-        }
-        case "thermostat_eco": {
-          /* only available in thermostat_mode 'cool' */
-          if (value) {
-            state.operationalMode = OPERATIONAL_MODE.COOL;
-
-            /* ECO mode disables boost and freeze protection */
-            this.setCapabilityValue("thermostat_boost", (state.turboMode = false));
-            this.setCapabilityValue("thermostat_freeze_protection", (state.freezeProtectionMode = false));
-          }
-          state.ecoMode = value; 
-          break; 
-        }
-        case "thermostat_freeze_protection": {
-          /* only available in thermostat_mode 'heat' */
-          if (value) {
-            state.operationalMode = OPERATIONAL_MODE.HEAT;
-
-            /* freeze protection mode disables boost and ECO */
-            this.setCapabilityValue("thermostat_eco", (state.ecoMode = false));
-            this.setCapabilityValue("thermostat_boost", (state.turboMode = false));
-          }
-          state.freezeProtectionMode = value; 
-          break; 
-        }
-        case "thermostat_fan_speed": {
-          switch (value) {
-            case "auto": {
-              if (state.operationalMode == OPERATIONAL_MODE.AUTO) {
-                state.fanSpeed = FAN_SPEED.FIXED; /* this is the default setting when thermostat_mode in 'auto' */
-              } else {
-                state.fanSpeed = FAN_SPEED.AUTO; /* only available in thermostat_mode 'heat' or 'cool' */
-              }
-              break;
-            }
-            case "silent": state.fanSpeed = FAN_SPEED.SILENT; break;
-            case "low": state.fanSpeed = FAN_SPEED.LOW; break;
-            case "medium": state.fanSpeed = FAN_SPEED.MEDIUM; break;
-            case "high": state.fanSpeed = FAN_SPEED.HIGH; break;
-            case "full": state.fanSpeed = FAN_SPEED.FULL; break;
-            default:
-              this.log("Value '" + value + "' for capability 'thermostat_fan_speed' does not exist");
-              break;
-          }
-          break;
-        }
-        case "thermostat_swing_mode": {
-          switch (value) {
-            case "off": state.swingMode = SWING_MODE.OFF; break;
-            case "both": state.swingMode = SWING_MODE.BOTH; break;
-            case "vertical": state.swingMode = SWING_MODE.VERTICAL; break;
-            case "horizontal": state.swingMode = SWING_MODE.HORIZONTAL; break;
-            default:
-              this.log("Value '" + value + "' for capability 'thermostat_swing_mode' does not exist");
-              break;
-          }
-          break;
-        }
-        default:
-          this.log("Capability '" + capability + "' does not exist");
-          break;
+  async onCapability(capability: string, value: unknown, opts: unknown) {
+    return this._runExclusive(async () => {
+      this.log(`Device::onCapability(capability='${capability}', value='`, value, '\')');
+      if (!this.hasCapability(capability)) {
+        throw new Error(`Capability '${capability}' is not supported by device [${this.getName()}]`);
       }
 
-      state = await new SetStateCommand(this._device, state).execute();
-      this._updateState(state);
-    } catch(err) {
-      this.error(err);
-      await this._refreshState(); // Revert UI to correct state
-      throw new Error("Error during adjustment of settings from device [" + this.getName() + "]"); 
-    } finally {
-      this._updatingState = false;
+      try {
+        let state = await this._getStateForCapabilityUpdate();
+
+        switch (capability) {
+          case 'onoff': state.powerOn = Boolean(value); break;
+          case 'target_temperature': state.targetTemperature = normalizeTargetTemperature(Number(value), this._getTargetTemperatureOptions()); break;
+          case 'thermostat_mode': {
+            switch (value) {
+              case 'auto': state.powerOn = true; state.operationalMode = OPERATIONAL_MODE.AUTO; break;
+              case 'cool': state.powerOn = true; state.operationalMode = OPERATIONAL_MODE.COOL; break;
+              case 'heat': state.powerOn = true; state.operationalMode = OPERATIONAL_MODE.HEAT; break;
+              case 'dry': state.powerOn = true; state.operationalMode = OPERATIONAL_MODE.DRY; break;
+              case 'fan': state.powerOn = true; state.operationalMode = OPERATIONAL_MODE.FAN; break;
+              case 'off': state.powerOn = false; break; /* this behaves exactly the same as the onoff button */
+              default:
+                this.log(`Value '${value}' for capability 'thermostat_mode' does not exist`);
+                break;
+            }
+            break;
+          }
+          case 'thermostat_boost': {
+            if (value) {
+              state.ecoMode = false;
+              state.freezeProtectionMode = false;
+            }
+            state.turboMode = Boolean(value); break; /* only available in thermostat_mode 'heat' or 'cool' */
+          }
+          case 'thermostat_eco': {
+            /* only available in thermostat_mode 'cool' */
+            if (value) {
+              state.operationalMode = OPERATIONAL_MODE.COOL;
+              state.turboMode = false;
+              state.freezeProtectionMode = false;
+            }
+            state.ecoMode = Boolean(value);
+            break;
+          }
+          case 'thermostat_freeze_protection': {
+            /* only available in thermostat_mode 'heat' */
+            if (value) {
+              state.operationalMode = OPERATIONAL_MODE.HEAT;
+              state.ecoMode = false;
+              state.turboMode = false;
+            }
+            state.freezeProtectionMode = Boolean(value);
+            break;
+          }
+          case 'thermostat_fan_speed': {
+            switch (value) {
+              case 'auto': {
+                if (state.operationalMode === OPERATIONAL_MODE.AUTO) {
+                  state.fanSpeed = FAN_SPEED.FIXED; /* this is the default setting when thermostat_mode in 'auto' */
+                } else {
+                  state.fanSpeed = FAN_SPEED.AUTO; /* only available in thermostat_mode 'heat' or 'cool' */
+                }
+                break;
+              }
+              case 'silent': state.fanSpeed = FAN_SPEED.SILENT; break;
+              case 'low': state.fanSpeed = FAN_SPEED.LOW; break;
+              case 'medium': state.fanSpeed = FAN_SPEED.MEDIUM; break;
+              case 'high': state.fanSpeed = FAN_SPEED.HIGH; break;
+              case 'full': state.fanSpeed = FAN_SPEED.FULL; break;
+              default:
+                this.log(`Value '${value}' for capability 'thermostat_fan_speed' does not exist`);
+                break;
+            }
+            break;
+          }
+          case 'thermostat_swing_mode': {
+            switch (value) {
+              case 'off': state.swingMode = SWING_MODE.OFF; break;
+              case 'both': state.swingMode = SWING_MODE.BOTH; break;
+              case 'vertical': state.swingMode = SWING_MODE.VERTICAL; break;
+              case 'horizontal': state.swingMode = SWING_MODE.HORIZONTAL; break;
+              default:
+                this.log(`Value '${value}' for capability 'thermostat_swing_mode' does not exist`);
+                break;
+            }
+            break;
+          }
+          default:
+            this.log(`Capability '${capability}' does not exist`);
+            break;
+        }
+
+        state = await this._withLanTimeout('set state', (device) => new SetStateCommand(device, state).execute());
+        await this._updateState(state);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.error(`Error applying capability '${capability}' for device [${this.getName()}]: ${message}`);
+        try {
+          await this._refreshStateUnsafe(); // Revert UI to correct state
+        } catch (refreshError) {
+          this.error(`Failed to refresh device [${this.getName()}] after capability error: ${
+            refreshError instanceof Error ? refreshError.message : String(refreshError)
+          }`);
+        }
+        throw new Error(`Error applying capability '${capability}' for device [${this.getName()}]: ${message}`);
+      }
+    });
+  }
+
+  private _createDeviceContext(): MDeviceContext {
+    const data = this.getData();
+    const store = this.getStore();
+    const deviceContext: MDeviceContext = new MDeviceContext();
+    deviceContext.id = data.id;
+    deviceContext.macAddress = data.macAddress;
+    deviceContext.udpId = data.udpId;
+    deviceContext.host = store.host || data.host;
+    deviceContext.port = store.port || data.port;
+
+    if (!deviceContext.host || !deviceContext.port) {
+      throw new Error('Missing LAN host or port; repair or re-add the device');
+    }
+
+    return deviceContext;
+  }
+
+  private _resetLanDevice() {
+    this._closeLanConnection();
+    this._lastState = null;
+
+    this._device = new MDevice(this._createDeviceContext());
+    const lanSecurityContext = this._getStoredLanSecurityContext();
+    if (lanSecurityContext) {
+      this._device.lanSecurityContext = lanSecurityContext;
     }
   }
+
+  private _closeLanConnection(device = this._device) {
+    if (device) {
+      const socket = (device as unknown as {
+        lanConnection?: { _socket?: { destroy?: () => void } };
+      }).lanConnection?._socket;
+      socket?.destroy?.();
+      device.close();
+    }
+  }
+
+  private _getStoredLanSecurityContext(): LANSecurityContext | null {
+    const store = this.getStore();
+    const token = typeof store.token === 'string' ? store.token : null;
+    const key = typeof store.key === 'string' ? store.key : null;
+
+    if (!token || !key) {
+      return null;
+    }
+
+    return new LANSecurityContext(token, key);
+  }
+
+  private async _getStateForCapabilityUpdate(): Promise<DeviceState> {
+    const state = await this._getFreshDeviceStateUnsafe('get state before capability update');
+    this._lastState = this._cloneDeviceState(state);
+    return this._cloneDeviceState(state);
+  }
+
+  private async _getFreshDeviceStateUnsafe(label: string): Promise<DeviceState> {
+    return this._withLanTimeout(label, (device) => new GetStateCommand(device).execute());
+  }
+
+  private _getTargetTemperatureOptions(): TargetTemperatureOptions | null {
+    const options = this.getCapabilityOptions('target_temperature') as Partial<TargetTemperatureOptions> | null;
+    if (
+      options
+      && typeof options.min === 'number'
+      && typeof options.max === 'number'
+      && typeof options.step === 'number'
+    ) {
+      return {
+        min: options.min,
+        max: options.max,
+        step: options.step,
+      };
+    }
+
+    return null;
+  }
+
+  private _cloneDeviceState(state: DeviceState): DeviceState {
+    const clone = new DeviceState();
+    clone.powerOn = state.powerOn;
+    clone.operationalMode = state.operationalMode;
+    clone.fanSpeed = state.fanSpeed;
+    clone.swingMode = state.swingMode;
+    clone.horizontalSwingAngle = state.horizontalSwingAngle;
+    clone.verticalSwingAngle = state.verticalSwingAngle;
+    clone.turboMode = state.turboMode;
+    clone.ecoMode = state.ecoMode;
+    clone.sleepMode = state.sleepMode;
+    clone.freezeProtectionMode = state.freezeProtectionMode;
+    clone.fahrenheit = state.fahrenheit;
+    clone.targetTemperature = state.targetTemperature;
+    clone.indoorTemperature = state.indoorTemperature;
+    clone.outdoorTemperature = state.outdoorTemperature;
+    clone.statusCode = state.statusCode;
+    return clone;
+  }
+
+  private _registerCapabilityListeners() {
+    SETTABLE_CAPABILITY_IDS.forEach((capability) => {
+      if (!this.hasCapability(capability) || this._registeredCapabilityListeners.has(capability)) {
+        return;
+      }
+
+      this.registerCapabilityListener(capability, async (value, opts) => this.onCapability(capability, value, opts));
+      this._registeredCapabilityListeners.add(capability);
+    });
+  }
+
+  private async _setCapabilityValueIfAvailable(capabilityId: string, value: CapabilityValue) {
+    if (this.hasCapability(capabilityId)) {
+      try {
+        await this.setCapabilityValue(capabilityId, value);
+      } catch (error) {
+        this.error(`Failed to update capability '${capabilityId}' for device [${this.getName()}] with value ${JSON.stringify(value)}: ${
+          error instanceof Error ? error.message : String(error)
+        }`);
+        throw error;
+      }
+    }
+  }
+
+  private async _runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this._commandQueue.catch((): undefined => undefined).then(operation);
+    this._commandQueue = run.then((): undefined => undefined, (): undefined => undefined);
+    return run;
+  }
+
+  private async _withLanTimeout<T>(label: string, operation: (device: MDevice) => Promise<T>): Promise<T> {
+    return this._withLanTimeoutAndOptionalRediscovery(label, operation, true);
+  }
+
+  private async _withLanTimeoutAndOptionalRediscovery<T>(
+    label: string,
+    operation: (device: MDevice) => Promise<T>,
+    allowRediscovery: boolean,
+  ): Promise<T> {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= LAN_OPERATION_ATTEMPTS; attempt++) {
+      try {
+        const result = await this._runLanOperationAttempt(label, operation);
+        if (label !== 'authenticate') {
+          this._resetLanDevice();
+        }
+        return result;
+      } catch (error) {
+        lastError = error;
+        this._resetLanDevice();
+        const deviceContext = this._createDeviceContext();
+        this.error(`LAN ${label} failed for device [${this.getName()}] at ${deviceContext.host}:${deviceContext.port} on attempt ${attempt}/${LAN_OPERATION_ATTEMPTS}: ${
+          error instanceof Error ? error.message : String(error)
+        }`);
+        if (attempt < LAN_OPERATION_ATTEMPTS) {
+          this.log(`${label} failed on attempt ${attempt}; retrying: ${
+            error instanceof Error ? error.message : String(error)
+          }`);
+        }
+      }
+    }
+
+    if (allowRediscovery && await this._rediscoverLanAddress(label)) {
+      return this._withLanTimeoutAndOptionalRediscovery(label, operation, false);
+    }
+
+    throw lastError;
+  }
+
+  private async _runLanOperationAttempt<T>(label: string, operation: (device: MDevice) => Promise<T>): Promise<T> {
+    let timer: NodeJS.Timeout | undefined;
+    const attemptDevice = this._device;
+
+    try {
+      return await Promise.race([
+        (async () => {
+          if (label !== 'authenticate') {
+            const lanSecurityContext = this._getStoredLanSecurityContext();
+            if (lanSecurityContext) {
+              await attemptDevice.authenticate(lanSecurityContext);
+            }
+          }
+
+          return operation(attemptDevice);
+        })(),
+        new Promise<T>((_resolve, reject) => {
+          timer = this.homey.setTimeout(
+            () => {
+              this._lastState = null;
+              this._closeLanConnection(attemptDevice);
+              reject(new Error(`${label} timed out after ${LAN_OPERATION_TIMEOUT_MS}ms`));
+            },
+            LAN_OPERATION_TIMEOUT_MS,
+          );
+        }),
+      ]);
+    } finally {
+      if (timer) {
+        this.homey.clearTimeout(timer);
+      }
+    }
+  }
+
+  private async _rediscoverLanAddress(label: string): Promise<boolean> {
+    const { rediscoverMideaDevice } = this.driver as unknown as RediscoveryDriver;
+    if (!rediscoverMideaDevice) {
+      return false;
+    }
+
+    const deviceContext = this._createDeviceContext();
+    try {
+      const result = await rediscoverMideaDevice.call(this.driver, {
+        id: deviceContext.id,
+        host: deviceContext.host,
+      });
+
+      if (!result || (result.host === deviceContext.host && result.port === deviceContext.port)) {
+        return false;
+      }
+
+      this.log(`Rediscovered Midea AC [${this.getName()}] during ${label}: ${deviceContext.host}:${deviceContext.port} -> ${result.host}:${result.port}`);
+      await this.setStoreValue('host', result.host);
+      await this.setStoreValue('port', result.port);
+      this._resetLanDevice();
+      return true;
+    } catch (error) {
+      this.error(`Rediscovery failed for Midea AC [${this.getName()}] during ${label}: ${
+        error instanceof Error ? error.message : String(error)
+      }`);
+      return false;
+    }
+  }
+
+  private async _setLastSeenAtIfAvailable() {
+    const { setLastSeenAt } = this as unknown as { setLastSeenAt?: () => Promise<void> };
+    if (setLastSeenAt) {
+      await setLastSeenAt.call(this);
+    }
+  }
+
 }
 
 module.exports = MideaDevice;

--- a/drivers/airco/discovery-targets.ts
+++ b/drivers/airco/discovery-targets.ts
@@ -1,0 +1,94 @@
+'use strict';
+
+export const MAX_AUTO_DISCOVERY_HOSTS = 512;
+export const MIN_AUTO_DISCOVERY_PREFIX = 23;
+
+function isIPv4(value: string): boolean {
+  const parts = value.split('.');
+  return parts.length === 4 && parts.every((part) => {
+    const number = Number(part);
+    return Number.isInteger(number) && number >= 0 && number <= 255 && String(number) === part;
+  });
+}
+
+function ipToInt(value: string): number {
+  return value.split('.').reduce((result, part) => ((result << 8) + Number(part)) >>> 0, 0);
+}
+
+function intToIp(value: number): string {
+  return [
+    (value >>> 24) & 255,
+    (value >>> 16) & 255,
+    (value >>> 8) & 255,
+    value & 255,
+  ].join('.');
+}
+
+export function getCidrHosts(address: string, prefix: number, maxHosts = MAX_AUTO_DISCOVERY_HOSTS): string[] {
+  if (!isIPv4(address) || !Number.isInteger(prefix) || prefix < 0 || prefix > 32) {
+    throw new Error('Enter a valid IPv4 CIDR range');
+  }
+
+  if (prefix === 32) {
+    return [address];
+  }
+
+  const size = 2 ** (32 - prefix);
+  const hostCount = prefix >= 31 ? size : size - 2;
+  if (hostCount > maxHosts) {
+    throw new Error('CIDR range is too large; use /23 or a narrower range');
+  }
+
+  const mask = (0xffffffff << (32 - prefix)) >>> 0;
+  const network = (ipToInt(address) & mask) >>> 0;
+  const first = prefix >= 31 ? network : network + 1;
+  const last = prefix >= 31 ? network + size - 1 : network + size - 2;
+  const hosts: string[] = [];
+
+  for (let ip = first; ip <= last; ip++) {
+    hosts.push(intToIp(ip));
+  }
+
+  return hosts;
+}
+
+export function netmaskToPrefix(netmask: string): number {
+  return ipToInt(netmask).toString(2).split('1').length - 1;
+}
+
+function getClassCHosts(address: string, maxHosts = MAX_AUTO_DISCOVERY_HOSTS): string[] {
+  const network = ipToInt(address) & 0xffffff00;
+  const hostCount = 256;
+  if (hostCount > maxHosts) {
+    throw new Error('Network range is too large');
+  }
+
+  const hosts: string[] = [];
+  for (let offset = 0; offset < hostCount; offset++) {
+    hosts.push(intToIp((network + offset) >>> 0));
+  }
+
+  return hosts;
+}
+
+export function getExplicitDiscoveryHosts(target: string, maxHosts = MAX_AUTO_DISCOVERY_HOSTS): string[] {
+  const value = target.trim();
+  const withoutGlobalBroadcast = (hosts: string[]) => hosts.filter((host) => host !== '255.255.255.255');
+
+  if (value.includes('/')) {
+    const parts = value.split('/');
+    if (parts.length !== 2) {
+      throw new Error('Enter a valid IPv4 CIDR range');
+    }
+
+    const [address, prefixText] = parts;
+    const prefix = Number(prefixText);
+    return withoutGlobalBroadcast(getCidrHosts(address, prefix, maxHosts));
+  }
+
+  if (!isIPv4(value)) {
+    throw new Error('Enter an IPv4 address');
+  }
+
+  return withoutGlobalBroadcast(getClassCHosts(value, maxHosts));
+}

--- a/drivers/airco/driver.compose.json
+++ b/drivers/airco/driver.compose.json
@@ -9,6 +9,7 @@
     "thermostat_mode",
     "target_temperature",
     "measure_temperature",
+    "measure_temperature.inside",
     "measure_temperature.outside",
     "thermostat_boost",
     "thermostat_fan_speed",
@@ -20,9 +21,15 @@
     "target_temperature": {
       "min": 16,
       "max": 30,
-      "step": 1
+      "step": 0.5
     },
     "measure_temperature": {
+      "title": {
+        "en": "Current temperature",
+        "nl": "Huidige temperatuur"
+      }
+    },
+    "measure_temperature.inside": {
       "title": {
         "en": "Inside temperature",
         "nl": "Binnentemperatuur"
@@ -43,13 +50,9 @@
   ],
   "pair": [
     {
-      "id": "list_devices",
-      "template": "list_devices",
-      "options": {
-        "singular": true
-      },
+      "id": "discovery",
       "navigation": {
-        "next": "token_and_key"
+        "next": "add_devices"
       }
     },
     {

--- a/drivers/airco/driver.ts
+++ b/drivers/airco/driver.ts
@@ -1,8 +1,162 @@
+'use strict';
+
+/* eslint-disable import/extensions, import/no-unresolved, node/no-missing-import */
 import Homey, { Device } from 'homey';
-import { _LOGGER, Driver as MDriver, Device as MDevice, DeviceContext as MDeviceContext, CloudSecurityContext, LANSecurityContext, DeviceState, GetStateCommand } from 'midea-msmarthome-ac-euosk105';
-import { FAN_SPEED, SWING_MODE, OPERATIONAL_MODE } from 'midea-msmarthome-ac-euosk105/dist/DeviceState';
+import * as crypto from 'crypto';
+import * as dgram from 'dgram';
+import * as net from 'net';
+import * as os from 'os';
+import {
+  CloudSecurityContext,
+  Device as MDevice,
+  DeviceCapabilities,
+  DeviceContext as MDeviceContext,
+  DeviceState,
+  Driver as MDriver,
+  GetCapabilitiesCommand,
+  GetStateCommand,
+  LANSecurityContext,
+  MIDEA_DISCOVER_BROADCAST_MSG,
+  Security,
+} from 'midea-msmarthome-ac-euosk105';
+import { getCapabilityOptions, getInitialCapabilityValues, getSupportedCapabilityIds } from './capabilities';
+import {
+  getCidrHosts,
+  getExplicitDiscoveryHosts,
+  MAX_AUTO_DISCOVERY_HOSTS,
+  MIN_AUTO_DISCOVERY_PREFIX,
+  netmaskToPrefix,
+} from './discovery-targets';
+
+const MIDEA_AC_APPLIANCE_TYPE = 172;
+const MIDEA_DISCOVERY_PORT = 6445;
+const DISCOVERY_BATCH_SIZE = 128;
+const DISCOVERY_BATCH_DELAY_MS = 10;
+const DISCOVERY_SETTLE_MS = 1800;
+const DEVICE_AUTH_TIMEOUT_MS = 15000;
+const LAN_AUTH_RESPONSE_SAMPLE_BYTES = 16;
+const MSMARTHOME_CONNECTION_TYPE = 0;
+const MIDEA_HANDSHAKE_REQUEST_MESSAGE_TYPE = 0;
+
+type PairDevice = {
+  name: string;
+  capabilities?: string[];
+  capabilitiesOptions?: {
+    [capabilityId: string]: object;
+  };
+  capabilitiesValues?: {
+    [capabilityId: string]: boolean | number | string | null;
+  };
+  data: {
+    id: number;
+    macAddress: string;
+    udpId: string;
+  };
+  store: {
+    host: string;
+    port: number;
+    serial?: string;
+    firmware?: string;
+    cloudName?: string;
+    cloudType?: string;
+    modelNumber?: string;
+    sn8?: string;
+    online?: boolean;
+    token?: string;
+    key?: string;
+    authError?: string;
+  };
+};
+
+type PairSession = {
+  setHandler: (name: string, handler: (data: unknown) => Promise<unknown>) => void;
+  emit: (event: string, data?: unknown) => Promise<void>;
+  done: () => Promise<void>;
+};
+
+type DiscoverySession = {
+  session: PairSession;
+  socket: dgram.Socket;
+  timers: NodeJS.Timeout[];
+  generation: number;
+  seenCandidates: Set<string>;
+  preparedIds: Set<string>;
+  pending: number;
+  ready: number;
+  skipped: number;
+  doneRequested: boolean;
+  stopped: boolean;
+};
+
+type TokenAndKeyData = {
+  devices: PairDevice[];
+  token: string;
+  key: string;
+};
+
+type LoginData = {
+  devices: PairDevice[];
+  username?: string;
+  password?: string;
+};
+
+type StartDiscoveryData = {
+  target?: string;
+  generation?: number;
+};
+
+type RediscoveryDevice = {
+  id: number;
+  host?: string;
+};
+
+type RediscoveryResult = {
+  host: string;
+  port: number;
+};
+
+type LanAuthDiagnostics = {
+  responseLength: number;
+  tcpKeyLength: number;
+  responsePrefix: string;
+  tcpKeyPrefix: string;
+  tcpKeyIsError: boolean;
+};
+
+type CloudApplianceMetadata = {
+  id: number;
+  name?: string;
+  type?: string;
+  modelNumber?: string;
+  sn8?: string;
+  online?: boolean;
+};
+
+type CloudApplianceResponse = {
+  id: number | string;
+  name?: string;
+  type?: string;
+  modelNumber?: string;
+  sn8?: string;
+  onlineStatus?: string;
+};
+
+type CloudApplianceListResponse = {
+  data?: {
+    list?: CloudApplianceResponse[];
+  };
+};
+
+type CloudConnectionWithExecute = {
+  executeCommand: (
+    cloudSecurityContext: CloudSecurityContext,
+    path: string,
+    body: object,
+  ) => Promise<CloudApplianceListResponse>;
+};
 
 class MideaDriver extends Homey.Driver {
+
   /**
    * onInit is called when the driver is initialized.
    */
@@ -11,44 +165,41 @@ class MideaDriver extends Homey.Driver {
 
     // THERMOSTAT BOOST
     this.homey.flow.getConditionCard('thermostat_boost_is_true').registerRunListener(async (args, state) => {
-      let deviceState: DeviceState = await new GetStateCommand(args.device._device).execute();
-      return (deviceState.turboMode);
+      return args.device.isBoostEnabled();
     });
 
     this.homey.flow.getActionCard('thermostat_boost_set_true').registerRunListener(async (args, state) => {
-      await args.device.onCapability("thermostat_boost", true, null);
+      await args.device.onCapability('thermostat_boost', true, null);
     });
 
     this.homey.flow.getActionCard('thermostat_boost_set_false').registerRunListener(async (args, state) => {
-      await args.device.onCapability("thermostat_boost", false, null);
+      await args.device.onCapability('thermostat_boost', false, null);
     });
 
     // THERMOSTAT ECO MODE
     this.homey.flow.getConditionCard('thermostat_eco_is_true').registerRunListener(async (args, state) => {
-      let deviceState: DeviceState = await new GetStateCommand(args.device._device).execute();
-      return (deviceState.ecoMode);
+      return args.device.isEcoEnabled();
     });
 
     this.homey.flow.getActionCard('thermostat_eco_set_true').registerRunListener(async (args, state) => {
-      await args.device.onCapability("thermostat_eco", true, null);
+      await args.device.onCapability('thermostat_eco', true, null);
     });
 
     this.homey.flow.getActionCard('thermostat_eco_set_false').registerRunListener(async (args, state) => {
-      await args.device.onCapability("thermostat_eco", false, null);
+      await args.device.onCapability('thermostat_eco', false, null);
     });
 
     // THERMOSTAT FREEZE PROTECTION MODE
     this.homey.flow.getConditionCard('thermostat_freeze_protection_is_true').registerRunListener(async (args, state) => {
-      let deviceState: DeviceState = await new GetStateCommand(args.device._device).execute();
-      return (deviceState.freezeProtectionMode);
+      return args.device.isFreezeProtectionEnabled();
     });
 
     this.homey.flow.getActionCard('thermostat_freeze_protection_set_true').registerRunListener(async (args, state) => {
-      await args.device.onCapability("thermostat_freeze_protection", true, null);
+      await args.device.onCapability('thermostat_freeze_protection', true, null);
     });
 
     this.homey.flow.getActionCard('thermostat_freeze_protection_set_false').registerRunListener(async (args, state) => {
-      await args.device.onCapability("thermostat_freeze_protection", false, null);
+      await args.device.onCapability('thermostat_freeze_protection', false, null);
     });
 
     // THERMOSTAT FAN SPEED
@@ -57,21 +208,11 @@ class MideaDriver extends Homey.Driver {
     });
 
     this.homey.flow.getConditionCard('thermostat_fan_speed_is').registerRunListener(async (args, state) => {
-      let deviceState: DeviceState = await new GetStateCommand(args.device._device).execute();
-      switch (deviceState.fanSpeed) {
-        case FAN_SPEED.AUTO: return args.fan_speed === "auto";
-        case FAN_SPEED.FIXED: return args.fan_speed === "auto";
-        case FAN_SPEED.SILENT: return args.fan_speed === "silent";
-        case FAN_SPEED.LOW: return args.fan_speed === "low";
-        case FAN_SPEED.MEDIUM: return args.fan_speed === "medium";
-        case FAN_SPEED.HIGH: return args.fan_speed === "high";
-        case FAN_SPEED.FULL: return args.fan_speed === "full";
-      }
-      return false;
+      return args.fan_speed === await args.device.getFanSpeedValue();
     });
 
     this.homey.flow.getActionCard('thermostat_fan_speed_set').registerRunListener(async (args, state) => {
-      await args.device.onCapability("thermostat_fan_speed", args.fan_speed, null);
+      await args.device.onCapability('thermostat_fan_speed', args.fan_speed, null);
     });
 
     // THERMOSTAT SWING MODE
@@ -80,18 +221,11 @@ class MideaDriver extends Homey.Driver {
     });
 
     this.homey.flow.getConditionCard('thermostat_swing_mode_is').registerRunListener(async (args, state) => {
-      let deviceState: DeviceState = await new GetStateCommand(args.device._device).execute();
-      switch (deviceState.swingMode) {
-        case SWING_MODE.OFF: return args.swing_mode === "off";
-        case SWING_MODE.BOTH: return args.swing_mode === "both";
-        case SWING_MODE.VERTICAL: return args.swing_mode === "vertical";
-        case SWING_MODE.HORIZONTAL: return args.swing_mode === "horizontal";
-      }
-      return false;
+      return args.swing_mode === await args.device.getSwingModeValue();
     });
 
     this.homey.flow.getActionCard('thermostat_swing_mode_set').registerRunListener(async (args, state) => {
-      await args.device.onCapability("thermostat_swing_mode", args.swing_mode, null);
+      await args.device.onCapability('thermostat_swing_mode', args.swing_mode, null);
     });
 
     // THERMOSTAT MODE
@@ -100,131 +234,108 @@ class MideaDriver extends Homey.Driver {
     });
 
     this.homey.flow.getConditionCard('thermostat_mode_is').registerRunListener(async (args, state) => {
-      let deviceState: DeviceState = await new GetStateCommand(args.device._device).execute();
-      switch (deviceState.operationalMode) {
-        case OPERATIONAL_MODE.AUTO: return args.thermostat_mode === "auto";
-        case OPERATIONAL_MODE.COOL: return args.thermostat_mode === "cool";
-        case OPERATIONAL_MODE.HEAT: return args.thermostat_mode === "heat";
-        case OPERATIONAL_MODE.DRY: return args.thermostat_mode === "dry";
-        case OPERATIONAL_MODE.FAN: return args.thermostat_mode === "fan";
-      }
-      return false;
+      return args.thermostat_mode === await args.device.getThermostatModeValue();
     });
 
     this.homey.flow.getActionCard('thermostat_mode_set').registerRunListener(async (args, state) => {
-      await args.device.onCapability("thermostat_mode", args.thermostat_mode, null);
+      await args.device.onCapability('thermostat_mode', args.thermostat_mode, null);
     });
   }
 
-  async onPair(session: any) {
-    session.setHandler("list_devices", async () => {
-      try {
-        let devices: any[] = [];
+  async onPair(session: PairSession) {
+    let discoverySession: DiscoverySession | null = null;
 
-        let mdevices: MDevice[] = await MDriver.listDevices();
-        mdevices.forEach(mdevice => {
-          const device = {
-            name: mdevice.deviceContext.ssid,
-            data: {
-              id: mdevice.deviceContext.id,
-              macAddress: mdevice.deviceContext.macAddress,
-              udpId: mdevice.deviceContext.udpId
-            },
-            store: {
-              host: mdevice.deviceContext.host,
-              port: mdevice.deviceContext.port,
-            }
-          };
-          devices.push(device);
-        });
-        return devices;
-      } catch (err) {
-        this.error(err);
-        return null;
-      }
-    });
-
-    session.setHandler("enterTokenAndKey", async (data: any) => {
-      try {
-        const device = data.devices[0]; 
-
-        let deviceContext: MDeviceContext = new MDeviceContext();
-        deviceContext.id = device.data.id;
-        deviceContext.macAddress = device.data.macAddress;
-        deviceContext.udpId = device.data.udpId;
-        deviceContext.host = device.store.host;
-        deviceContext.port = device.store.port;
-
-        let mdevice: MDevice = new MDevice(deviceContext)
-
-        await mdevice.authenticate(new LANSecurityContext(data.token, data.key));
-        device.store.token = data.token;
-        device.store.key = data.key;
-
-        return device;
-      } catch (err) {
-        this.error(err);
-        return null;
-      }
-    });
-
-    session.setHandler("login", async (data: any) => {
+    session.setHandler('enterTokenAndKey', async (payload: unknown) => {
+      const data = payload as TokenAndKeyData;
       try {
         const device = data.devices[0];
+        if (!device) {
+          return null;
+        }
 
-        let deviceContext: MDeviceContext = new MDeviceContext();
-        deviceContext.id = device.data.id;
-        deviceContext.macAddress = device.data.macAddress;
-        deviceContext.udpId = device.data.udpId;
-        deviceContext.host = device.store.host;
-        deviceContext.port = device.store.port;
-
-        let mdevice: MDevice = new MDevice(deviceContext)
-
-        let cloudSecurityContext: CloudSecurityContext = new CloudSecurityContext(data.username, data.password);
-        let lanSecurityContext: LANSecurityContext  = await MDriver.retrieveTokenAndKeyFromCloud(mdevice, cloudSecurityContext);
-        device.store.token = lanSecurityContext.token;
-        device.store.key = lanSecurityContext.key;
-
-        return device;
+        return this.preparePairDeviceWithTokenAndKey(device, data.token, data.key);
       } catch (err) {
         this.error(err);
-        return null;
+        throw err;
       }
+    });
+
+    session.setHandler('login', async (payload: unknown) => {
+      const data = payload as LoginData;
+      try {
+        this.log(`login handler called for ${data && data.devices ? data.devices.length : 0} device(s)`);
+        return this.preparePairDevices(data.devices, data.username, data.password);
+      } catch (err) {
+        this.error(err);
+        return {
+          devices: [] as PairDevice[],
+          failed: data && data.devices ? data.devices : [],
+        };
+      }
+    });
+
+    session.setHandler('startDiscovery', async (payload: unknown) => {
+      const data = payload as StartDiscoveryData;
+      try {
+        this.stopDiscovery(discoverySession);
+        discoverySession = this.createDiscoverySession(session, data && data.generation);
+        this.startDiscovery(discoverySession, data && data.target);
+        return { started: true };
+      } catch (err) {
+        this.error(err);
+        return { started: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    });
+
+    session.setHandler('stopDiscovery', async () => {
+      this.stopDiscovery(discoverySession);
+      discoverySession = null;
+      return { stopped: true };
+    });
+
+    session.setHandler('prepareDevices', async (payload: unknown) => {
+      const data = payload as LoginData;
+      this.log(`prepareDevices handler called for ${data && data.devices ? data.devices.length : 0} device(s), credentials=${data && (data.username || data.password) ? 'provided' : 'default'}`);
+      return this.preparePairDevices(data.devices, data.username, data.password);
     });
   }
 
-  async onRepair(session: any, device: Device) {
-    session.setHandler("reinitializeDevice", async (data: any) => {
+  async onRepair(session: PairSession, device: Device) {
+    session.setHandler('reinitializeDevice', async () => {
       const mdevices = await MDriver.listDevices();
-			const mdevice = mdevices.find((mdevice) => device.getData().id === mdevice.deviceContext.id);
-      if(mdevice) {
+      const mdevice = mdevices.find((mdevice) => device.getData().id === mdevice.deviceContext.id);
+      if (mdevice) {
         if (mdevice.deviceContext.host !== device.getStore().host) {
           // IP ADDRESS OF THE DEVICE HAS CHANGED ==> RESET HOST and CLEAR TOKEN AND KEY
-          device.setStoreValue("host", mdevice.deviceContext.host);
-          device.setStoreValue("port", mdevice.deviceContext.port);
-          device.setStoreValue("token", null);
-          device.setStoreValue("key", null);
+          await device.setStoreValue('host', mdevice.deviceContext.host);
+          await device.setStoreValue('port', mdevice.deviceContext.port);
+          await device.setStoreValue('token', null);
+          await device.setStoreValue('key', null);
         }
         return device.getStore();
       }
       return null;
-    })
+    });
 
-    session.setHandler("enterTokenAndKey", async (data: any) => {
+    session.setHandler('enterTokenAndKey', async (payload: unknown) => {
+      const data = payload as TokenAndKeyData;
+      let mdevice: MDevice | null = null;
       try {
-        let deviceContext: MDeviceContext = new MDeviceContext();
+        const deviceContext: MDeviceContext = new MDeviceContext();
         deviceContext.id = device.getData().id;
         deviceContext.macAddress = device.getData().macAddress;
         deviceContext.udpId = device.getData().udpId;
         deviceContext.host = device.getStore().host;
         deviceContext.port = device.getStore().port;
 
-        let mdevice: MDevice = new MDevice(deviceContext)
+        mdevice = new MDevice(deviceContext);
 
         await mdevice.authenticate(new LANSecurityContext(data.token, data.key));
-        device.setStoreValue("token", data.token);
-        device.setStoreValue("key", data.key);
+        await device.setStoreValue('token', data.token);
+        await device.setStoreValue('key', data.key);
+
+        mdevice.close();
+        mdevice = null;
 
         await device.onInit();
         await session.done();
@@ -232,32 +343,832 @@ class MideaDriver extends Homey.Driver {
       } catch (err) {
         this.error(err);
         return null;
+      } finally {
+        if (mdevice) {
+          mdevice.close();
+        }
       }
     });
 
-    session.setHandler("login", async (data: any) => {
+    session.setHandler('login', async (payload: unknown) => {
+      const data = payload as LoginData;
+      let mdevice: MDevice | null = null;
       try {
-        let deviceContext: MDeviceContext = new MDeviceContext();
+        const deviceContext: MDeviceContext = new MDeviceContext();
         deviceContext.id = device.getData().id;
         deviceContext.macAddress = device.getData().macAddress;
         deviceContext.udpId = device.getData().udpId;
         deviceContext.host = device.getStore().host;
         deviceContext.port = device.getStore().port;
 
-        let mdevice: MDevice = new MDevice(deviceContext)
+        mdevice = new MDevice(deviceContext);
 
-        let cloudSecurityContext: CloudSecurityContext = new CloudSecurityContext(data.username, data.password);
-        let lanSecurityContext: LANSecurityContext  = await MDriver.retrieveTokenAndKeyFromCloud(mdevice, cloudSecurityContext);
-        device.setStoreValue("token", lanSecurityContext.token);
-        device.setStoreValue("key", lanSecurityContext.key);
+        const cloudSecurityContext: CloudSecurityContext = new CloudSecurityContext(data.username, data.password);
+        const lanSecurityContext: LANSecurityContext = await MDriver.retrieveTokenAndKeyFromCloud(mdevice, cloudSecurityContext);
+        await device.setStoreValue('token', lanSecurityContext.token);
+        await device.setStoreValue('key', lanSecurityContext.key);
 
+        mdevice.close();
+        mdevice = null;
+
+        await device.onInit();
+        await session.done();
         return device;
       } catch (err) {
         this.error(err);
         return null;
+      } finally {
+        if (mdevice) {
+          mdevice.close();
+        }
       }
     });
   }
+
+  private createDiscoverySession(session: PairSession, generation?: number): DiscoverySession {
+    const discoverySession: DiscoverySession = {
+      session,
+      socket: dgram.createSocket('udp4'),
+      timers: [],
+      generation: generation || 0,
+      seenCandidates: new Set<string>(),
+      preparedIds: new Set<string>(),
+      pending: 0,
+      ready: 0,
+      skipped: 0,
+      doneRequested: false,
+      stopped: false,
+    };
+
+    discoverySession.socket.on('message', (message, info) => {
+      this.handleDiscoveryMessage(discoverySession, message, info.address).catch((error) => this.error(error));
+    });
+
+    discoverySession.socket.on('error', (error) => {
+      this.handleDiscoveryError(discoverySession, error).catch((emitError) => this.error(emitError));
+    });
+
+    return discoverySession;
+  }
+
+  private async handleDiscoveryMessage(discoverySession: DiscoverySession, message: Buffer, host: string) {
+    if (discoverySession.stopped) {
+      return;
+    }
+
+    const mdevice = this.parseDiscoveryResponse(message, host);
+    if (!mdevice) {
+      return;
+    }
+
+    const device = this.createPairDevice(mdevice);
+    const candidateKey = this.getDiscoveryCandidateKey(device);
+    const stableKey = this.getStableDeviceKey(device);
+    if (
+      discoverySession.seenCandidates.has(candidateKey)
+      || discoverySession.preparedIds.has(stableKey)
+    ) {
+      return;
+    }
+
+    discoverySession.seenCandidates.add(candidateKey);
+    if (this.isAlreadyPairedDevice(device)) {
+      device.store.authError = 'Device is already paired';
+      discoverySession.skipped++;
+      if (!discoverySession.stopped) {
+        await discoverySession.session.emit('deviceCandidateFailed', {
+          generation: discoverySession.generation,
+          device,
+        });
+      }
+      await this.emitDiscoveryProgress(discoverySession);
+      return;
+    }
+
+    discoverySession.pending++;
+    try {
+      const result = await this.preparePairDevices([device]);
+      const preparedDevice = result.devices[0];
+      const failedDevice = result.failed[0];
+
+      if (
+        preparedDevice
+        && !discoverySession.stopped
+        && !discoverySession.preparedIds.has(stableKey)
+      ) {
+        discoverySession.preparedIds.add(stableKey);
+        discoverySession.ready++;
+        await discoverySession.session.emit('deviceFound', {
+          generation: discoverySession.generation,
+          device: preparedDevice,
+        });
+      } else {
+        discoverySession.skipped++;
+        if (failedDevice && !discoverySession.stopped) {
+          await discoverySession.session.emit('deviceCandidateFailed', {
+            generation: discoverySession.generation,
+            device: failedDevice,
+          });
+        }
+        await this.emitDiscoveryProgress(discoverySession);
+      }
+    } catch (error) {
+      discoverySession.skipped++;
+      this.error(`Skipping discovered Midea device ${device.data.id} at ${device.store.host}: ${
+        error instanceof Error ? error.message : String(error)
+      }`);
+      if (!discoverySession.stopped) {
+        await discoverySession.session.emit('deviceCandidateFailed', {
+          generation: discoverySession.generation,
+          device,
+        });
+      }
+      await this.emitDiscoveryProgress(discoverySession);
+    } finally {
+      discoverySession.pending--;
+      await this.finishDiscoveryIfReady(discoverySession);
+    }
+  }
+
+  private async handleDiscoveryError(discoverySession: DiscoverySession, error: Error) {
+    if (!discoverySession.stopped) {
+      this.error(error);
+      await discoverySession.session.emit('discoveryError', {
+        generation: discoverySession.generation,
+        error: error.message,
+      });
+    }
+    this.stopDiscovery(discoverySession);
+  }
+
+  private startDiscovery(discoverySession: DiscoverySession, target?: string) {
+    const explicitTarget = Boolean(target && target.trim());
+    const hosts = explicitTarget
+      ? getExplicitDiscoveryHosts(target)
+      : this.getLocalDiscoveryHosts();
+
+    discoverySession.socket.bind({}, () => {
+      discoverySession.socket.setBroadcast(true);
+      if (!explicitTarget) {
+        this.sendDiscoveryPacket(discoverySession, '255.255.255.255');
+      }
+      this.sendDiscoveryHosts(discoverySession, hosts);
+    });
+  }
+
+  private sendDiscoveryHosts(discoverySession: DiscoverySession, hosts: string[]) {
+    for (let offset = 0; offset < hosts.length; offset += DISCOVERY_BATCH_SIZE) {
+      const batch = hosts.slice(offset, offset + DISCOVERY_BATCH_SIZE);
+      const timer = this.homey.setTimeout(() => {
+        batch.forEach((host) => this.sendDiscoveryPacket(discoverySession, host));
+      }, (offset / DISCOVERY_BATCH_SIZE) * DISCOVERY_BATCH_DELAY_MS);
+      discoverySession.timers.push(timer);
+    }
+
+    const doneDelay = Math.ceil(hosts.length / DISCOVERY_BATCH_SIZE) * DISCOVERY_BATCH_DELAY_MS + DISCOVERY_SETTLE_MS;
+    const doneTimer = this.homey.setTimeout(() => {
+      if (!discoverySession.stopped) {
+        discoverySession.doneRequested = true;
+        this.finishDiscoveryIfReady(discoverySession).catch((error) => this.error(error));
+      }
+    }, doneDelay);
+    discoverySession.timers.push(doneTimer);
+  }
+
+  private async emitDiscoveryProgress(discoverySession: DiscoverySession) {
+    if (!discoverySession.stopped) {
+      await discoverySession.session.emit('discoveryProgress', {
+        generation: discoverySession.generation,
+        seen: discoverySession.seenCandidates.size,
+        ready: discoverySession.ready,
+        skipped: discoverySession.skipped,
+        pending: discoverySession.pending,
+      });
+    }
+  }
+
+  private async finishDiscoveryIfReady(discoverySession: DiscoverySession) {
+    if (
+      discoverySession.stopped
+      || !discoverySession.doneRequested
+      || discoverySession.pending > 0
+    ) {
+      return;
+    }
+
+    await discoverySession.session.emit('discoveryDone', {
+      generation: discoverySession.generation,
+      count: discoverySession.ready,
+      ready: discoverySession.ready,
+      skipped: discoverySession.skipped,
+      seen: discoverySession.seenCandidates.size,
+    });
+    this.stopDiscovery(discoverySession);
+  }
+
+  private sendDiscoveryPacket(discoverySession: DiscoverySession, host: string) {
+    if (discoverySession.stopped) {
+      return;
+    }
+    discoverySession.socket.send(
+      MIDEA_DISCOVER_BROADCAST_MSG,
+      0,
+      MIDEA_DISCOVER_BROADCAST_MSG.length,
+      MIDEA_DISCOVERY_PORT,
+      host,
+    );
+  }
+
+  private stopDiscovery(discoverySession: DiscoverySession | null) {
+    if (!discoverySession || discoverySession.stopped) {
+      return;
+    }
+
+    discoverySession.stopped = true;
+    discoverySession.timers.forEach((timer) => this.homey.clearTimeout(timer));
+    try {
+      discoverySession.socket.close();
+    } catch (error) {
+      // The socket may already be closed by a previous cancellation path.
+    }
+  }
+
+  private getLocalDiscoveryHosts(): string[] {
+    const hosts = new Set<string>();
+    const interfaces = os.networkInterfaces();
+
+    Object.values(interfaces).forEach((items) => {
+      (items || []).forEach((item) => {
+        if (item.family !== 'IPv4' || item.internal) {
+          return;
+        }
+
+        const prefix = Math.max(netmaskToPrefix(item.netmask), MIN_AUTO_DISCOVERY_PREFIX);
+        getCidrHosts(item.address, prefix, MAX_AUTO_DISCOVERY_HOSTS)
+          .forEach((host) => hosts.add(host));
+      });
+    });
+
+    return Array.from(hosts);
+  }
+
+  private getDiscoveryCandidateKey(device: PairDevice): string {
+    return `${this.getStableDeviceKey(device)}:${device.store.host}`;
+  }
+
+  private getStableDeviceKey(device: PairDevice): string {
+    return device.data.id ? `id:${device.data.id}` : `mac:${device.data.macAddress || device.data.udpId}`;
+  }
+
+  private isAlreadyPairedDevice(device: PairDevice): boolean {
+    return this.getDevices().some((homeyDevice) => {
+      const data = homeyDevice.getData() as Partial<PairDevice['data']>;
+
+      return (
+        typeof data.id === 'number'
+        && data.id === device.data.id
+      ) || (
+        Boolean(data.macAddress)
+        && data.macAddress === device.data.macAddress
+      ) || (
+        Boolean(data.udpId)
+        && data.udpId === device.data.udpId
+      );
+    });
+  }
+
+  async rediscoverMideaDevice(device: RediscoveryDevice): Promise<RediscoveryResult | null> {
+    const hosts = this.getRediscoveryHosts(device.host);
+    const devices = await this.discoverMideaPairDevices(hosts);
+    const discoveredDevice = devices.find((candidate) => candidate.data.id === device.id);
+
+    if (!discoveredDevice) {
+      return null;
+    }
+
+    return {
+      host: discoveredDevice.store.host,
+      port: discoveredDevice.store.port,
+    };
+  }
+
+  private getRediscoveryHosts(host?: string): string[] {
+    const hosts = new Set<string>();
+
+    if (host) {
+      getCidrHosts(host, 24, MAX_AUTO_DISCOVERY_HOSTS)
+        .forEach((candidate) => hosts.add(candidate));
+    }
+
+    this.getLocalDiscoveryHosts()
+      .forEach((candidate) => hosts.add(candidate));
+
+    return Array.from(hosts);
+  }
+
+  private async discoverMideaPairDevices(hosts: string[]): Promise<PairDevice[]> {
+    return new Promise((resolve, reject) => {
+      const socket = dgram.createSocket('udp4');
+      const devices: PairDevice[] = [];
+      const seen = new Set<string>();
+      let closed = false;
+
+      const close = () => {
+        if (!closed) {
+          closed = true;
+          socket.close();
+        }
+      };
+
+      socket.on('message', (message, info) => {
+        const mdevice = this.parseDiscoveryResponse(message, info.address);
+        if (!mdevice) {
+          return;
+        }
+
+        const device = this.createPairDevice(mdevice);
+        const key = this.getDiscoveryCandidateKey(device);
+        if (seen.has(key)) {
+          return;
+        }
+
+        seen.add(key);
+        devices.push(device);
+      });
+
+      socket.on('error', (error) => {
+        close();
+        reject(error);
+      });
+
+      socket.bind({}, () => {
+        socket.setBroadcast(true);
+        hosts.forEach((host) => {
+          socket.send(
+            MIDEA_DISCOVER_BROADCAST_MSG,
+            0,
+            MIDEA_DISCOVER_BROADCAST_MSG.length,
+            MIDEA_DISCOVERY_PORT,
+            host,
+          );
+        });
+      });
+
+      this.homey.setTimeout(() => {
+        close();
+        resolve(devices);
+      }, DISCOVERY_SETTLE_MS);
+    });
+  }
+
+  private async preparePairDevices(devices: PairDevice[], username?: string, password?: string) {
+    const preparedDevices: PairDevice[] = [];
+    const failed: PairDevice[] = [];
+    const cloudMetadata = await this.getCloudApplianceMetadata(devices || [], username, password);
+
+    for (const device of devices || []) {
+      try {
+        if (this.isAlreadyPairedDevice(device)) {
+          device.store.authError = 'Device is already paired';
+          failed.push(device);
+          continue;
+        }
+
+        this.applyCloudMetadata(device, cloudMetadata.get(device.data.id));
+        this.log(`Preparing Midea device ${device.data.id} at ${device.store.host}`);
+        const cloudSecurityContext = username || password
+          ? new CloudSecurityContext(username, password)
+          : null;
+        const {
+          udpId,
+          lanSecurityContext,
+          capabilities,
+          state,
+        } = await this.withTimeout(
+          this.prepareDeviceWithUdpIdCandidates(device, cloudSecurityContext),
+          DEVICE_AUTH_TIMEOUT_MS,
+          'Timed out while authenticating the device',
+        );
+        this.applyPreparedDevice(device, udpId, lanSecurityContext, capabilities, state);
+        preparedDevices.push(device);
+        this.log(`Prepared Midea device ${device.data.id} at ${device.store.host}`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        device.store.authError = message;
+        this.error(`Failed to prepare Midea device ${device.data.id} at ${device.store.host}: ${message}`);
+        failed.push(device);
+      }
+    }
+
+    return {
+      devices: preparedDevices,
+      failed,
+    };
+  }
+
+  private async preparePairDeviceWithTokenAndKey(device: PairDevice, token: string, key: string): Promise<PairDevice> {
+    if (this.isAlreadyPairedDevice(device)) {
+      throw new Error('Device is already paired');
+    }
+
+    const {
+      udpId,
+      lanSecurityContext,
+      capabilities,
+      state,
+    } = await this.withTimeout(
+      this.prepareDeviceWithTokenAndKeyCandidates(device, token, key),
+      DEVICE_AUTH_TIMEOUT_MS,
+      'Timed out while authenticating the device',
+    );
+
+    this.applyPreparedDevice(device, udpId, lanSecurityContext, capabilities, state);
+    return device;
+  }
+
+  private applyPreparedDevice(
+    device: PairDevice,
+    udpId: string,
+    lanSecurityContext: LANSecurityContext,
+    capabilities: DeviceCapabilities,
+    state: DeviceState,
+  ) {
+    device.data.udpId = udpId;
+    device.capabilities = getSupportedCapabilityIds(capabilities);
+    device.capabilitiesOptions = getCapabilityOptions(capabilities);
+    device.capabilitiesValues = getInitialCapabilityValues(state, device.capabilities);
+    device.store.token = lanSecurityContext.token;
+    device.store.key = lanSecurityContext.key;
+    delete device.store.authError;
+  }
+
+  private async getCloudApplianceMetadata(
+    devices: PairDevice[],
+    username?: string,
+    password?: string,
+  ): Promise<Map<number, CloudApplianceMetadata>> {
+    const metadataById = new Map<number, CloudApplianceMetadata>();
+    if (!devices.length || !username || !password) {
+      return metadataById;
+    }
+
+    try {
+      const cloudSecurityContext = new CloudSecurityContext(username, password, MSMARTHOME_CONNECTION_TYPE);
+      const cloudConnection = cloudSecurityContext.getCloudConnection(this.createMideaDevice(devices[0])) as CloudConnectionWithExecute;
+      const response = await this.withTimeout(
+        cloudConnection.executeCommand(cloudSecurityContext, '/v1/appliance/user/list/get', {}),
+        DEVICE_AUTH_TIMEOUT_MS,
+        'Timed out while retrieving device names from the MSmartHome cloud',
+      );
+      const appliances = response && response.data && Array.isArray(response.data.list)
+        ? response.data.list
+        : [];
+
+      appliances.forEach((appliance) => {
+        const id = Number(appliance.id);
+        if (!Number.isFinite(id)) {
+          return;
+        }
+
+        metadataById.set(id, {
+          id,
+          name: appliance.name,
+          type: appliance.type,
+          modelNumber: appliance.modelNumber,
+          sn8: appliance.sn8,
+          online: appliance.onlineStatus === '1',
+        });
+      });
+
+      this.log(`Retrieved MSmartHome metadata for ${metadataById.size} appliance(s)`);
+    } catch (error) {
+      this.error(`Failed to retrieve MSmartHome device metadata: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    return metadataById;
+  }
+
+  private applyCloudMetadata(device: PairDevice, metadata?: CloudApplianceMetadata) {
+    if (!metadata) {
+      return;
+    }
+
+    if (metadata.name) {
+      device.name = metadata.name;
+      device.store.cloudName = metadata.name;
+    }
+    device.store.cloudType = metadata.type;
+    device.store.modelNumber = metadata.modelNumber;
+    device.store.sn8 = metadata.sn8;
+    device.store.online = metadata.online;
+  }
+
+  private async prepareDeviceWithUdpIdCandidates(
+    device: PairDevice,
+    cloudSecurityContext: CloudSecurityContext | null,
+  ): Promise<{ udpId: string; lanSecurityContext: LANSecurityContext; capabilities: DeviceCapabilities; state: DeviceState }> {
+    let lastError: Error | null = null;
+
+    for (const udpId of this.getUdpIdCandidates(device)) {
+      let mdevice: MDevice | null = null;
+      try {
+        mdevice = this.createMideaDevice(device, udpId);
+        const lanSecurityContext = await MDriver.retrieveTokenAndKeyFromCloud(mdevice, cloudSecurityContext);
+        this.log(`Retrieved token and key for Midea device ${device.data.id} using udpId ${udpId}`);
+        const { capabilities, state } = await this.prepareAuthenticatedMideaDevice(device, mdevice, lanSecurityContext);
+        return {
+          udpId,
+          lanSecurityContext,
+          capabilities,
+          state,
+        };
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        this.error(`Failed token/key and LAN auth flow for Midea device ${device.data.id} using udpId ${udpId}: ${lastError.message}`);
+      } finally {
+        if (mdevice) {
+          mdevice.close();
+        }
+      }
+    }
+
+    throw lastError || new Error('Unable to retrieve token and key from the Midea cloud or authenticate locally');
+  }
+
+  private async prepareDeviceWithTokenAndKeyCandidates(
+    device: PairDevice,
+    token: string,
+    key: string,
+  ): Promise<{ udpId: string; lanSecurityContext: LANSecurityContext; capabilities: DeviceCapabilities; state: DeviceState }> {
+    let lastError: Error | null = null;
+
+    for (const udpId of this.getUdpIdCandidates(device)) {
+      let mdevice: MDevice | null = null;
+      try {
+        mdevice = this.createMideaDevice(device, udpId);
+        const lanSecurityContext = new LANSecurityContext(token, key);
+        const { capabilities, state } = await this.prepareAuthenticatedMideaDevice(device, mdevice, lanSecurityContext);
+        return {
+          udpId,
+          lanSecurityContext,
+          capabilities,
+          state,
+        };
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        this.error(`Failed manual token/key LAN auth flow for Midea device ${device.data.id} using udpId ${udpId}: ${lastError.message}`);
+      } finally {
+        if (mdevice) {
+          mdevice.close();
+        }
+      }
+    }
+
+    throw lastError || new Error('Unable to authenticate locally with the provided token and key');
+  }
+
+  private async prepareAuthenticatedMideaDevice(
+    device: PairDevice,
+    mdevice: MDevice,
+    lanSecurityContext: LANSecurityContext,
+  ): Promise<{ capabilities: DeviceCapabilities; state: DeviceState }> {
+    await this.authenticateDeviceForPairing(device, mdevice, lanSecurityContext);
+    const capabilities = await new GetCapabilitiesCommand(mdevice).execute();
+    const state = await new GetStateCommand(mdevice).execute();
+    return { capabilities, state };
+  }
+
+  private getUdpIdCandidates(device: PairDevice): string[] {
+    return Array.from(new Set([
+      device.data.udpId,
+      this.createUdpId(device.data.id, 'little'),
+      this.createUdpId(device.data.id, 'big'),
+    ].filter(Boolean)));
+  }
+
+  private createUdpId(deviceId: number, endian: 'little' | 'big'): string {
+    if (!Number.isSafeInteger(deviceId) || deviceId < 0) {
+      throw new Error(`Invalid Midea device id: ${deviceId}`);
+    }
+
+    const bytes = Buffer.alloc(6);
+
+    if (endian === 'little') {
+      bytes.writeUIntLE(deviceId, 0, bytes.length);
+    } else {
+      bytes.writeUIntBE(deviceId, 0, bytes.length);
+    }
+
+    const hash = crypto.createHash('sha256').update(bytes).digest();
+    const udpId = Buffer.alloc(16);
+    for (let index = 0; index < udpId.length; index++) {
+      udpId[index] = hash[index] ^ hash[index + 16];
+    }
+
+    return udpId.toString('hex');
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+    let timer: NodeJS.Timeout | undefined;
+
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<T>((resolve, reject) => {
+          timer = this.homey.setTimeout(() => reject(new Error(message)), timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timer) {
+        this.homey.clearTimeout(timer);
+      }
+    }
+  }
+
+  private async authenticateDeviceForPairing(
+    device: PairDevice,
+    mdevice: MDevice,
+    lanSecurityContext: LANSecurityContext,
+  ): Promise<void> {
+    try {
+      await mdevice.authenticate(lanSecurityContext);
+    } catch (error) {
+      const originalError = error instanceof Error ? error.message : String(error);
+      this.error(`LAN authentication failed for Midea device ${device.data.id} at ${device.store.host}:${device.store.port}: ${originalError}`);
+
+      const probe = await this.probeLanAuthentication(device, lanSecurityContext);
+      mdevice.lanSecurityContext = probe;
+      this.log(`LAN authentication recovered on retry for Midea device ${device.data.id} at ${device.store.host}:${device.store.port}`);
+    }
+  }
+
+  private async probeLanAuthentication(device: PairDevice, lanSecurityContext: LANSecurityContext): Promise<LANSecurityContext> {
+    let diagnostics: LanAuthDiagnostics | null = null;
+
+    try {
+      const encoded = Security.encode8370(
+        lanSecurityContext,
+        Buffer.from(lanSecurityContext.token, 'hex'),
+        0,
+        MIDEA_HANDSHAKE_REQUEST_MESSAGE_TYPE,
+      );
+      const response = await this.executeLanHandshake(device, encoded.data);
+      const tcpKeyData = response.slice(8, 72);
+      diagnostics = this.getLanAuthDiagnostics(response, tcpKeyData);
+      const updatedSecurityContext = await Security.tcpKey(lanSecurityContext, tcpKeyData);
+      this.log(`LAN authentication probe succeeded for Midea device ${device.data.id} at ${device.store.host}:${device.store.port}: ${this.formatLanAuthDiagnostics(diagnostics)}`);
+      return updatedSecurityContext;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const diagnosticMessage = diagnostics
+        ? `${message}; ${this.formatLanAuthDiagnostics(diagnostics)}`
+        : message;
+      this.error(`LAN authentication probe failed for Midea device ${device.data.id} at ${device.store.host}:${device.store.port}: ${diagnosticMessage}`);
+      throw new Error(diagnosticMessage);
+    }
+  }
+
+  private async executeLanHandshake(device: PairDevice, message: Buffer): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const socket = new net.Socket();
+      let settled = false;
+
+      const finish = (error: Error | null, response?: Buffer) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        socket.destroy();
+
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(response || Buffer.alloc(0));
+      };
+
+      socket.setTimeout(DEVICE_AUTH_TIMEOUT_MS);
+      socket.once('error', (error) => {
+        finish(error instanceof Error ? error : new Error(String(error)));
+      });
+      socket.once('timeout', () => {
+        finish(new Error('LAN handshake timed out'));
+      });
+      socket.once('data', (response) => {
+        finish(null, response);
+      });
+
+      socket.connect(device.store.port, device.store.host, () => {
+        socket.write(message, (error) => {
+          if (error) {
+            finish(error instanceof Error ? error : new Error(String(error)));
+          }
+        });
+      });
+    });
+  }
+
+  private getLanAuthDiagnostics(response: Buffer, tcpKeyData: Buffer): LanAuthDiagnostics {
+    return {
+      responseLength: response.length,
+      tcpKeyLength: tcpKeyData.length,
+      responsePrefix: response.subarray(0, LAN_AUTH_RESPONSE_SAMPLE_BYTES).toString('hex'),
+      tcpKeyPrefix: tcpKeyData.subarray(0, LAN_AUTH_RESPONSE_SAMPLE_BYTES).toString('hex'),
+      tcpKeyIsError: tcpKeyData.toString('utf8') === 'ERROR',
+    };
+  }
+
+  private formatLanAuthDiagnostics(diagnostics: LanAuthDiagnostics): string {
+    return [
+      `responseLength=${diagnostics.responseLength}`,
+      `tcpKeyLength=${diagnostics.tcpKeyLength}`,
+      `responsePrefix=${diagnostics.responsePrefix || '<empty>'}`,
+      `tcpKeyPrefix=${diagnostics.tcpKeyPrefix || '<empty>'}`,
+      `tcpKeyIsError=${diagnostics.tcpKeyIsError}`,
+    ].join(', ');
+  }
+
+  private createPairDevice(mdevice: MDevice): PairDevice {
+    return {
+      name: mdevice.deviceContext.ssid || 'Air conditioner',
+      data: {
+        id: mdevice.deviceContext.id,
+        macAddress: mdevice.deviceContext.macAddress,
+        udpId: mdevice.deviceContext.udpId,
+      },
+      store: {
+        host: mdevice.deviceContext.host,
+        port: mdevice.deviceContext.port,
+        serial: mdevice.deviceContext.serial,
+        firmware: mdevice.deviceContext.firmware,
+      },
+    };
+  }
+
+  private createMideaDevice(device: PairDevice, udpId = device.data.udpId): MDevice {
+    const deviceContext: MDeviceContext = new MDeviceContext();
+    deviceContext.id = device.data.id;
+    deviceContext.macAddress = device.data.macAddress;
+    deviceContext.udpId = udpId;
+    deviceContext.host = device.store.host;
+    deviceContext.port = device.store.port;
+
+    return new MDevice(deviceContext);
+  }
+
+  private parseDiscoveryResponse(message: Buffer, host: string): MDevice | null {
+    try {
+      let msg = message;
+      const context = new MDeviceContext();
+
+      if (msg[0] === 0x83 || msg[1] === 0x70) {
+        context.version = 3;
+        msg = msg.subarray(8, msg.length - 16);
+      } else if (msg[0] === 0x5A || msg[1] === 0x5A) {
+        context.version = 2;
+      }
+
+      if (msg[0] !== 0x5A || msg.length < 104) {
+        return null;
+      }
+
+      const data = Security.aesDecrypt(msg.subarray(40, msg.length - 16));
+      context.applianceType = data[55 + data[40]];
+      const idHex = msg.subarray(20, 26).toString('hex').match(/../g).reverse()
+        .join('');
+      context.id = parseInt(idHex, 16);
+      context.ssid = data.subarray(41, 41 + data[40]).toString();
+      context.macAddress = Array.from(data.subarray(63 + data[40], 69 + data[40]))
+        .map((byte) => byte.toString(16))
+        .join(':');
+      context.host = host;
+      context.port = parseInt(data.subarray(4, 8).toString('hex').match(/../g).reverse()
+        .join(''), 16);
+      context.serial = data.subarray(8, 40).toString();
+      context.firmware = `${data[72 + data[40]]}.${data[73 + data[40]]}.${data[74 + data[40]]}`;
+
+      if (context.version === 3) {
+        const hash = crypto.createHash('sha256').update(Buffer.from(idHex, 'hex')).digest();
+        const b1 = hash.subarray(0, 16);
+        const b2 = hash.subarray(16);
+        const b3 = Buffer.alloc(16);
+        for (let i = 0; i < b1.length; i++) {
+          b3[i] = b1[i] ^ b2[i];
+        }
+        context.udpId = b3.toString('hex');
+      }
+
+      if (context.version === 3 && context.applianceType === MIDEA_AC_APPLIANCE_TYPE) {
+        return new MDevice(context);
+      }
+    } catch (error) {
+      this.error(error);
+    }
+    return null;
+  }
+
 }
 
 module.exports = MideaDriver;

--- a/drivers/airco/pair/discovery.html
+++ b/drivers/airco/pair/discovery.html
@@ -1,0 +1,571 @@
+<html>
+
+<body>
+	<script type="application/javascript">
+		let devicesByKey = {};
+		let failedDevicesByKey = {};
+		let preparedDevices = [];
+		let searchGeneration = 0;
+
+		$(document).ready(function() {
+			const navBarFromDiscovery = document.getElementById("hy-nav");
+			if (navBarFromDiscovery) {
+				navBarFromDiscovery.remove();
+			}
+
+			Homey.on('deviceFound', function(payload) {
+				if (!isCurrentPayload(payload)) {
+					return;
+				}
+
+				addDevice(payload.device);
+			});
+
+			Homey.on('deviceCandidateFailed', function(payload) {
+				if (!isCurrentPayload(payload)) {
+					return;
+				}
+
+				addFailedDevice(payload.device);
+			});
+
+			Homey.on('discoveryDone', function(progress) {
+				if (!isCurrentPayload(progress)) {
+					return;
+				}
+
+				updateDiscoveryStatus(progress, true);
+			});
+
+			Homey.on('discoveryError', function(payload) {
+				if (!isCurrentPayload(payload)) {
+					return;
+				}
+
+				Homey.error(payload.error || Homey.__("pair.discovery.error"));
+				setStatus(Homey.__("pair.discovery.error"));
+			});
+
+			Homey.on('discoveryProgress', function(progress) {
+				if (!isCurrentPayload(progress)) {
+					return;
+				}
+
+				updateDiscoveryStatus(progress, false);
+			});
+
+			startDiscovery();
+		});
+
+		function startDiscovery(target) {
+			searchGeneration++;
+			const generation = searchGeneration;
+
+			resetDiscoveryState();
+			setStatus(Homey.__("pair.discovery.searching"));
+			Homey.emit('startDiscovery', { target: target || "", generation: generation }, function(error, result) {
+				if (generation !== searchGeneration) {
+					return;
+				}
+
+				if (error) {
+					Homey.error(error);
+					setStatus(Homey.__("pair.discovery.error"));
+				} else if (!result || !result.started) {
+					Homey.error(result && result.error ? result.error : Homey.__("pair.discovery.error"));
+					setStatus(Homey.__("pair.discovery.error"));
+				}
+			});
+		}
+
+		function searchTarget(event) {
+			event.preventDefault();
+
+			const target = document.getElementById("target").value.trim();
+			if (!target) {
+				Homey.error(Homey.__("pair.discovery.targetRequired"));
+				return;
+			}
+
+			startDiscovery(target);
+		}
+
+		function resetDiscoveryState() {
+			devicesByKey = {};
+			failedDevicesByKey = {};
+			preparedDevices = [];
+			renderDevices();
+		}
+
+		function isCurrentPayload(payload) {
+			return payload && payload.generation === searchGeneration;
+		}
+
+		function getDeviceKey(device) {
+			return device.data.id + ":" + device.store.host;
+		}
+
+		function addDevice(device) {
+			const key = getDeviceKey(device);
+			if (devicesByKey[key]) {
+				return;
+			}
+
+			devicesByKey[key] = device;
+			delete failedDevicesByKey[key];
+			Object.keys(failedDevicesByKey).forEach(function(failedKey) {
+				if (failedDevicesByKey[failedKey].data.id === device.data.id) {
+					delete failedDevicesByKey[failedKey];
+				}
+			});
+			renderDevices();
+		}
+
+		function addFailedDevice(device) {
+			const key = getDeviceKey(device);
+			if (devicesByKey[key] || failedDevicesByKey[key]) {
+				return;
+			}
+
+			failedDevicesByKey[key] = device;
+			renderDevices();
+		}
+
+		function isAlreadyPaired(device) {
+			return device && device.store && device.store.authError === "Device is already paired";
+		}
+
+		function getFailedDeviceReason(device) {
+			return isAlreadyPaired(device)
+				? Homey.__("pair.discovery.alreadyPaired")
+				: Homey.__("pair.discovery.needsAuth");
+		}
+
+		function renderDevices() {
+			const list = document.getElementById("devices");
+			const empty = document.getElementById("empty");
+			const devices = Object.values(devicesByKey);
+			const failedDevices = Object.values(failedDevicesByKey);
+
+			list.innerHTML = "";
+			empty.style.display = devices.length || failedDevices.length ? "none" : "block";
+
+			devices.forEach(function(device) {
+				const key = getDeviceKey(device);
+				const row = document.createElement("label");
+				row.className = "midea-device-row";
+
+				const checkbox = document.createElement("input");
+				checkbox.type = "checkbox";
+				checkbox.value = key;
+				checkbox.checked = true;
+				checkbox.addEventListener("change", updateSelectionState);
+
+				const iconWrap = document.createElement("span");
+				iconWrap.className = "midea-device-icon";
+
+				const icon = document.createElement("img");
+				icon.src = "../assets/icon.svg";
+				icon.alt = "";
+				icon.setAttribute("aria-hidden", "true");
+				iconWrap.appendChild(icon);
+
+				const check = document.createElement("span");
+				check.className = "midea-check";
+
+				const text = document.createElement("span");
+				text.className = "midea-device-copy";
+
+					const title = document.createElement("strong");
+					title.className = "midea-device-title";
+					title.textContent = device.name || Homey.__("pair.discovery.deviceTitle");
+
+				const details = document.createElement("small");
+				details.className = "midea-device-details";
+				details.textContent = Homey.__("pair.discovery.ipAddress") + " " + device.store.host;
+
+				text.appendChild(title);
+				text.appendChild(details);
+
+				row.appendChild(checkbox);
+				row.appendChild(iconWrap);
+				row.appendChild(text);
+				row.appendChild(check);
+				list.appendChild(row);
+			});
+
+			failedDevices.forEach(function(device) {
+				const row = document.createElement("div");
+				row.className = "midea-device-row midea-device-row-failed";
+
+				const iconWrap = document.createElement("span");
+				iconWrap.className = "midea-device-icon";
+
+				const icon = document.createElement("img");
+				icon.src = "../assets/icon.svg";
+				icon.alt = "";
+				icon.setAttribute("aria-hidden", "true");
+				iconWrap.appendChild(icon);
+
+				const text = document.createElement("span");
+				text.className = "midea-device-copy";
+
+				const title = document.createElement("strong");
+				title.className = "midea-device-title";
+				title.textContent = device.name || Homey.__("pair.discovery.deviceTitle");
+
+				const details = document.createElement("small");
+				details.className = "midea-device-details";
+				details.textContent = Homey.__("pair.discovery.ipAddress") + " " + device.store.host + " - " + getFailedDeviceReason(device);
+
+				text.appendChild(title);
+				text.appendChild(details);
+
+				row.appendChild(iconWrap);
+				row.appendChild(text);
+
+				if (!isAlreadyPaired(device)) {
+					const action = document.createElement("button");
+					action.type = "button";
+					action.className = "midea-device-action";
+					action.textContent = Homey.__("pair.discovery.useCredentialsOrToken");
+					action.addEventListener("click", function(event) {
+						event.preventDefault();
+						preparedDevices = getSelectedDevices();
+						showCredentialsFallback([device]);
+					});
+
+					row.appendChild(action);
+				}
+				list.appendChild(row);
+			});
+
+			updateSelectionState();
+		}
+
+		function updateSelectionState() {
+			const selectedCount = getSelectedDevices().length;
+			const addButton = document.getElementById("add-selected");
+			addButton.disabled = selectedCount === 0;
+			addButton.textContent = selectedCount
+				? Homey.__("pair.discovery.addSelected") + " (" + selectedCount + ")"
+				: Homey.__("pair.discovery.addSelected");
+
+			Array.from(document.querySelectorAll(".midea-device-row")).forEach(function(row) {
+				const checkbox = row.querySelector("input");
+				row.classList.toggle("is-selected", checkbox && checkbox.checked);
+			});
+		}
+
+		function getSelectedDevices() {
+			return Array.from(document.querySelectorAll("#devices input:checked"))
+				.map(function(input) {
+					return devicesByKey[input.value];
+				})
+				.filter(Boolean);
+		}
+
+		function addSelected(event) {
+			event.preventDefault();
+
+			const selectedDevices = getSelectedDevices();
+			if (!selectedDevices.length) {
+				Homey.error(Homey.__("pair.discovery.selectDevice"));
+				return;
+			}
+
+			Homey.showLoadingOverlay();
+			Homey.emit('stopDiscovery', {}, function() {
+				Homey.setViewStoreValue("add_devices", "devices", selectedDevices).then(function() {
+					Homey.setViewStoreValue("add_devices", "preparedDevices", []).then(function() {
+						Homey.hideLoadingOverlay();
+						Homey.showView("add_devices");
+					});
+				});
+			});
+		}
+
+		function prepareDevices(devices, username, password) {
+			if (!devices || !devices.length) {
+				Homey.error(Homey.__("pair.discovery.selectDevice"));
+				return;
+			}
+
+			setAuthBusy(true);
+			Homey.emit('prepareDevices', {
+					devices: devices,
+					username: username,
+					password: password
+				},
+				function(error, result) {
+					Homey.hideLoadingOverlay();
+					setAuthBusy(false);
+					if (error) {
+						Homey.error(error);
+						showCredentialsFallback(devices);
+						return;
+					}
+
+					const addedDevices = result && result.devices ? result.devices : [];
+					const failedDevices = result && result.failed ? result.failed : [];
+
+					if (addedDevices.length) {
+						preparedDevices = preparedDevices.concat(addedDevices);
+					}
+
+					if (!failedDevices.length) {
+						Homey.setViewStoreValue("add_devices", "devices", preparedDevices).then(function() {
+							Homey.setViewStoreValue("add_devices", "preparedDevices", []).then(function() {
+								Homey.showView("add_devices");
+							});
+						});
+						return;
+					}
+
+					showCredentialsFallback(failedDevices);
+				}
+			);
+		}
+
+		function showCredentialsFallback(devices) {
+			setStatus(Homey.__("pair.discovery.authFailed"));
+			Homey.setViewStoreValue("add_devices", "preparedDevices", preparedDevices).then(function() {
+				Homey.setViewStoreValue("add_devices", "devices", devices).then(function() {
+					Homey.showView("token_and_key");
+				});
+			});
+		}
+
+		function setAuthBusy(isBusy) {
+			const addButton = document.getElementById("add-selected");
+
+			if (isBusy) {
+				setStatus(Homey.__("pair.discovery.authenticating"));
+			}
+
+			addButton.disabled = isBusy || getSelectedDevices().length === 0;
+		}
+
+		function setStatus(message) {
+			document.getElementById("status").textContent = message;
+		}
+
+		function updateDiscoveryStatus(progress, isDone) {
+			if (!progress) {
+				setStatus(isDone ? Homey.__("pair.discovery.done") : Homey.__("pair.discovery.searching"));
+				return;
+			}
+
+			const parts = [];
+			if (progress.ready) {
+				parts.push(Homey.__("pair.discovery.ready") + " " + progress.ready);
+			}
+			if (progress.pending) {
+				parts.push(Homey.__("pair.discovery.validating") + " " + progress.pending);
+			}
+			if (progress.skipped) {
+				parts.push(Homey.__("pair.discovery.skipped") + " " + progress.skipped);
+			}
+
+			const prefix = isDone ? Homey.__("pair.discovery.done") : Homey.__("pair.discovery.searching");
+			setStatus(parts.length ? prefix + " " + parts.join(", ") : prefix);
+		}
+	</script>
+
+	<style>
+		#discovery {
+			box-sizing: border-box;
+			padding: 0;
+			width: 100%;
+		}
+
+		#status {
+			line-height: 1.35;
+			margin-bottom: 0;
+			margin-top: 6px;
+		}
+
+		.midea-section {
+			margin-top: 18px;
+		}
+
+		.midea-device-list {
+			display: grid;
+			gap: 12px;
+			margin-top: 12px;
+		}
+
+		.midea-device-row {
+			align-items: center;
+			background: #fff;
+			border: 1px solid rgba(0, 0, 0, 0.09);
+			border-radius: 8px;
+			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+			box-sizing: border-box;
+			cursor: pointer;
+			display: grid;
+			gap: 12px;
+			grid-template-columns: 46px minmax(0, 1fr) 22px;
+			min-height: 72px;
+			padding: 12px;
+			position: relative;
+			-webkit-tap-highlight-color: transparent;
+			transition: background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+			user-select: none;
+			width: 100%;
+		}
+
+		.midea-device-row:hover {
+			background: rgba(0, 130, 250, 0.045);
+			border-color: rgba(0, 130, 250, 0.24);
+			box-shadow: 0 2px 7px rgba(0, 0, 0, 0.07);
+		}
+
+		.midea-device-row.is-selected {
+			background: rgba(0, 130, 250, 0.06);
+			border-color: rgba(0, 130, 250, 0.42);
+			box-shadow: 0 2px 8px rgba(0, 0, 0, 0.075);
+		}
+
+		.midea-device-row-failed {
+			cursor: default;
+			grid-template-columns: 46px minmax(0, 1fr) minmax(96px, auto);
+		}
+
+		.midea-device-row:focus-within {
+			border-color: rgba(0, 130, 250, 0.62);
+			box-shadow: 0 0 0 3px rgba(0, 130, 250, 0.14);
+			outline: 0;
+		}
+
+		.midea-device-row input {
+			height: 1px;
+			opacity: 0;
+			position: absolute;
+			width: 1px;
+		}
+
+		.midea-device-icon {
+			align-items: center;
+			background: rgba(0, 130, 250, 0.08);
+			border-radius: 8px;
+			display: flex;
+			height: 46px;
+			justify-content: center;
+			width: 46px;
+		}
+
+		.midea-device-icon img {
+			display: block;
+			height: 26px;
+			opacity: 0.72;
+			width: 26px;
+		}
+
+		.midea-device-row.is-selected .midea-device-icon {
+			background: rgba(0, 130, 250, 0.12);
+		}
+
+		.midea-device-row.is-selected .midea-device-icon img {
+			opacity: 0.86;
+		}
+
+		.midea-check {
+			align-self: center;
+			border: 2px solid rgba(0, 0, 0, 0.26);
+			border-radius: 50%;
+			box-sizing: border-box;
+			display: block;
+			height: 22px;
+			justify-self: end;
+			position: relative;
+			width: 22px;
+		}
+
+		.midea-device-row.is-selected .midea-check {
+			background: #0078ff;
+			border-color: #0078ff;
+		}
+
+		.midea-device-row.is-selected .midea-check::after {
+			border: solid #fff;
+			border-width: 0 2px 2px 0;
+			content: "";
+			height: 8px;
+			left: 50%;
+			position: absolute;
+			top: 46%;
+			transform: translate(-50%, -50%) rotate(45deg);
+			transform-origin: 50% 50%;
+			width: 5px;
+		}
+
+		.midea-device-copy {
+			display: block;
+			min-width: 0;
+			overflow: hidden;
+		}
+
+		.midea-device-title,
+		.midea-device-details {
+			display: block;
+		}
+
+		.midea-device-title {
+			font-weight: 600;
+			line-height: 1.25;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		.midea-device-details {
+			color: rgba(0, 0, 0, 0.54);
+			font-size: 12px;
+			line-height: 1.35;
+			overflow: hidden;
+			padding-top: 2px;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		.midea-device-action {
+			align-self: center;
+			background: transparent;
+			border: 0;
+			color: #0078ff;
+			cursor: pointer;
+			font: inherit;
+			font-size: 12px;
+			font-weight: 600;
+			justify-self: end;
+			padding: 6px 0;
+			text-align: right;
+		}
+
+	</style>
+
+	<div id="discovery">
+		<h1 class="homey-title homey-text-align-center" data-i18n="pair.discovery.title">Find Midea devices</h1>
+		<p id="status" class="homey-subtitle" data-i18n="pair.discovery.searching">Searching for devices...</p>
+
+		<div class="midea-section">
+			<div id="empty" class="homey-text-small" data-i18n="pair.discovery.empty">Validated devices will appear here when ready.</div>
+			<div id="devices" class="midea-device-list"></div>
+		</div>
+
+		<form class="homey-form midea-section" onsubmit="searchTarget(event); return false;">
+			<div class="homey-form-group-large">
+				<label class="homey-form-label" for="target" data-i18n="pair.discovery.targetLabel">Search another network</label>
+				<input class="homey-form-input-large" id="target" name="target" type="text" placeholder="192.0.2.0" value="" />
+			</div>
+			<button type="submit" class="homey-button-secondary-shadow-full" data-i18n="pair.discovery.searchTarget">Search this network</button>
+		</form>
+
+		<form class="homey-form midea-section" onsubmit="addSelected(event); return false;">
+			<button id="add-selected" type="submit" class="homey-button-primary-shadow-full" data-i18n="pair.discovery.addSelected" disabled>Add selected</button>
+		</form>
+	</div>
+</body>
+
+</html>

--- a/drivers/airco/pair/login_credentials.html
+++ b/drivers/airco/pair/login_credentials.html
@@ -2,14 +2,14 @@
 
 <body>
 	<script type="application/javascript">
-		$(document).ready( function() {
-			const navBarFromLoginCredentials = document.getElementById("hy-nav");
-			if(navBarFromLoginCredentials) {
-				navBarFromLoginCredentials.remove();
-			}
-			document.getElementById("username").value = Homey.__("repair.login_credentials.usernamePlaceholder");
-			document.getElementById("password").value = Homey.__("repair.login_credentials.passwordPlaceholder");
-		});
+			$(document).ready( function() {
+				const navBarFromLoginCredentials = document.getElementById("hy-nav");
+				if(navBarFromLoginCredentials) {
+					navBarFromLoginCredentials.remove();
+				}
+				document.getElementById("username").placeholder = Homey.__("pair.login_credentials.usernamePlaceholder");
+				document.getElementById("password").placeholder = Homey.__("pair.login_credentials.passwordPlaceholder");
+			});
 
 		function login(event) {
 			event.preventDefault();
@@ -17,29 +17,38 @@
 			Homey.showLoadingOverlay();
 
 			Homey.getViewStoreValue("add_devices", "devices").then(devices => {
-				Homey.emit('login', {
-						devices: devices,
-						username: document.getElementById("username").value,
-						password: document.getElementById("password").value
-					},
-					function (error, device) {
-						if (error) {
-							Homey.error(error);
-						} else if (!device) {
-							Homey.error(Homey.__("pair.error_adding_device"));
-						} else if (device) {
-							Homey.setViewStoreValue("add_devices", "devices", [device]);
-							Homey.showView("token_and_key");
-						}
-						Homey.hideLoadingOverlay();
-					},
-				);
+				Homey.getViewStoreValue("add_devices", "preparedDevices").then(preparedDevices => {
+					Homey.emit('login', {
+							devices: devices,
+							username: document.getElementById("username").value,
+							password: document.getElementById("password").value
+						},
+						function (error, result) {
+							const addedDevices = result && result.devices ? result.devices : (result ? [result] : []);
+							const allDevices = (preparedDevices || []).concat(addedDevices);
+
+							if (error) {
+								Homey.error(error);
+							} else if (!allDevices.length) {
+								Homey.error(Homey.__("pair.error_adding_device"));
+							} else {
+								Homey.setViewStoreValue("add_devices", "devices", allDevices).then(function() {
+									Homey.setViewStoreValue("add_devices", "preparedDevices", []).then(function() {
+										Homey.showView("add_devices");
+									});
+								});
+							}
+							Homey.hideLoadingOverlay();
+						},
+					);
+				});
 			});
 		};
-	</script>
+
+		</script>
 
 	<div id="login-credentials">
-		<form id="login-credentials-form" class="homey-form">
+		<form id="login-credentials-form" class="homey-form" onsubmit="login(event); return false;">
 			<h1 id="login-credentials-title" class="homey-title homey-text-align-center"
 				data-i18n="pair.login_credentials.title">Log in with your device</h1>
 			<span data-i18n="pair.login_credentials.message"></span>
@@ -48,14 +57,14 @@
 					address</label>
 				<input class="homey-form-input-large" id="username" name="username" type="text" value=""/>
 			</div>
-			<div class="homey-form-group-large">
-				<label class="homey-form-label" for="password"
-					data-i18n="pair.login_credentials.passwordLabel">Password</label>
-				<input class="homey-form-input-large" id="password" name="password" type="password" value=""/>
-			</div>
-			<button class="homey-button-primary-shadow-full" onclick="login(event)">Log in</button>
-		</form>
-	</div>
+				<div class="homey-form-group-large">
+					<label class="homey-form-label" for="password"
+						data-i18n="pair.login_credentials.passwordLabel">Password</label>
+					<input class="homey-form-input-large" id="password" name="password" type="password" value=""/>
+				</div>
+				<button class="homey-button-primary-shadow-full" type="submit">Log in</button>
+			</form>
+		</div>
 </body>
 
 </html>

--- a/drivers/airco/pair/token_and_key.html
+++ b/drivers/airco/pair/token_and_key.html
@@ -19,9 +19,8 @@
 		function enterTokenAndKey(event) {
 			event.preventDefault();
 
-			Homey.showLoadingOverlay();
-
 			if (document.getElementById("token").value && document.getElementById("key").value) {
+				Homey.showLoadingOverlay();
 				Homey.getViewStoreValue("add_devices", "devices").then(devices => {
 					Homey.emit('enterTokenAndKey', {
 							devices: devices,
@@ -38,8 +37,13 @@
 								document.getElementById("token").value = "";
 								document.getElementById("key").value = "";
 							} else if (device) {
-								Homey.setViewStoreValue("add_devices", "devices", [device]);
-								Homey.showView("add_devices");
+								Homey.getViewStoreValue("add_devices", "preparedDevices").then(preparedDevices => {
+									Homey.setViewStoreValue("add_devices", "devices", (preparedDevices || []).concat([device])).then(function() {
+										Homey.setViewStoreValue("add_devices", "preparedDevices", []).then(function() {
+											Homey.showView("add_devices");
+										});
+									});
+								});
 							}
 							Homey.hideLoadingOverlay();
 						},

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,9 +1,34 @@
 {
   "pair": {
     "error_adding_device": "Error while adding device",
+    "discovery": {
+      "title": "Find Midea devices",
+      "searching": "Searching for devices...",
+      "done": "Search complete",
+      "error": "Error while searching for devices",
+      "empty": "Validated devices will appear here when ready.",
+      "deviceTitle": "Air conditioner",
+      "ipAddress": "IP",
+      "targetLabel": "Search another network",
+      "ready": "Ready:",
+      "validating": "Validating:",
+      "skipped": "Skipped:",
+      "searchTarget": "Search this network",
+      "addSelected": "Add selected",
+      "selectDevice": "Select at least one device",
+      "targetRequired": "Enter an IP address in the network to search",
+      "authenticating": "Authenticating selected devices...",
+      "authFailed": "Authentication failed. Continue with your MSmartHome credentials.",
+      "authErrorPrefix": "Last error:",
+      "retryCredentials": "Continue with credentials",
+      "useTokenKey": "Continue with token and key",
+      "needsAuth": "needs credentials or token",
+      "alreadyPaired": "already paired",
+      "useCredentialsOrToken": "Use token or credentials"
+    },
     "token_and_key": {
       "title": "Enter token and key of the device",
-      "message": "If the token and key of the device are known, values can be entered here. they can be entered manually or automatically retrieved from the cloud in the next screen (leave fields empty and press continue).",
+      "message": "If automatic authentication fails and the token and key of the device are known, values can be entered here.",
       "tokenLabel": "Token",
       "keyLabel": "Key",
       "ipAdressLabel": "IP Address"

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,9 +1,34 @@
 {
   "pair": {
     "error_adding_device": "Fout bij het toevoegen van een device",
+    "discovery": {
+      "title": "Midea-apparaten zoeken",
+      "searching": "Apparaten zoeken...",
+      "done": "Zoeken voltooid",
+      "error": "Fout bij het zoeken naar apparaten",
+      "empty": "Gevalideerde apparaten verschijnen hier zodra ze klaar zijn.",
+      "deviceTitle": "Airconditioner",
+      "ipAddress": "IP",
+      "targetLabel": "Zoek een ander netwerk",
+      "ready": "Klaar:",
+      "validating": "Valideren:",
+      "skipped": "Overgeslagen:",
+      "searchTarget": "Zoek dit netwerk",
+      "addSelected": "Geselecteerde toevoegen",
+      "selectDevice": "Selecteer minimaal een apparaat",
+      "targetRequired": "Voer een IP-adres in het netwerk in",
+      "authenticating": "Geselecteerde apparaten authenticeren...",
+      "authFailed": "Authenticatie mislukt. Ga verder met uw MSmartHome-inloggegevens.",
+      "authErrorPrefix": "Laatste fout:",
+      "retryCredentials": "Doorgaan met inloggegevens",
+      "useTokenKey": "Doorgaan met token en key",
+      "needsAuth": "inloggegevens of token nodig",
+      "alreadyPaired": "al gekoppeld",
+      "useCredentialsOrToken": "Gebruik token of inloggegevens"
+    },
     "token_and_key": {
       "title": "Voer de token en de key van het device in",
-      "message": "Als de token en de key van het apparaat bekend zijn, kunnen hier waarden worden ingevoerd. Deze kunnen handmatig worden ingevoerd of automatisch worden opgehaald uit de cloud in het volgende scherm (velden leeg laten en op Doorgaan drukken).",
+      "message": "Als automatische authenticatie mislukt en de token en key van het apparaat bekend zijn, kunnen deze hier worden ingevoerd.",
       "tokenLabel": "Token",
       "keyLabel": "Key",
       "ipAdressLabel": "IP Adres"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nl.intyme.midea",
-  "version": "1.0.14",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nl.intyme.midea",
-      "version": "1.0.14",
+      "version": "1.0.18",
       "dependencies": {
         "crypto-js": "^4.2.0",
         "dateformat": "^4.6.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,10 @@
     "outDir": ".homeybuild/",
     "strictPropertyInitialization": false,
     "strictNullChecks": false
-  }
+  },
+  "exclude": [
+    "node_modules",
+    ".homeybuild",
+    "scripts/verify-helpers.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

This PR makes Midea/Toshiba-style AC pairing and control local-first, with automatic recovery when LAN sessions expire or a device IP changes. It also replaces the single-device broadcast-only pairing path with a validated multi-device discovery flow that can work on routed local networks.

The user-facing goal is to reduce the need for repair/re-pair actions:

- pairing validates that a discovered candidate is actually addable before showing it as a normal device
- multiple validated AC units can be selected and added from one pairing run
- manual "Search another network" accepts an IP-like network hint such as `192.0.2.0` and scans the full last-octet range for that network
- token/key and cloud-login pairing flows reuse the same validation path and return initial capability values
- runtime polling/control refreshes LAN state safely, resets timed-out sessions, and tries rediscovery before marking the device unavailable
- static capabilities are no longer re-derived during runtime polling

## Why this is a larger PR

Several reported symptoms share the same root cause: discovery, validation, Homey device identity, LAN authentication, capability setup, and runtime state refresh were tightly coupled. Fixing only one of those paths still leaves users with devices that can be discovered but not added, added but not controllable, or temporarily working until the LAN session or IP changes.

This is still one logical change: make the AC driver local-first and self-healing across pairing, polling, Flow conditions, and control.

## User impact

- Devices on routed local networks can be found without needing global broadcast to work.
- Already paired devices are recognized by stable identifiers instead of mutable host/port data.
- Pairing distinguishes validated devices from candidates that responded but could not be authenticated.
- Failed candidates now show an actionable route to the token/key or cloud-login fallback instead of appearing silently broken.
- Newly added devices start with populated Homey capability values instead of empty state.
- Existing devices can recover from an expired LAN socket/session by reconnecting and refreshing state.
- Existing devices can recover when the same unit appears at a new IP by rediscovering and updating stored host/port.
- Control actions and Flow conditions use the same serialized fresh-state LAN path, reducing stale writes and silent Flow mismatches.
- Temperature values keep decimal precision where supported, inside/current/outside readings are separated, and unsupported/outdoor placeholder values are not surfaced as real readings.
- Capability controls stay stable after pairing, so normal polling only updates state instead of reshaping the device UI.

## Main changes

- Added `drivers/airco/capabilities.ts` for conservative static capability definitions and capability value filtering.
- Added `drivers/airco/discovery-targets.ts` for explicit discovery target parsing.
- Reworked `drivers/airco/driver.ts` pairing discovery around validated candidates, stable Homey identity, token/key fallback, and rediscovery.
- Reworked `drivers/airco/device.ts` runtime LAN operations so polling and control use serialized fresh-state operations with timeout cleanup.
- Added a minimal discovery pairing view that shows validated devices first and failed candidates separately.
- Added initial `capabilitiesValues` during pairing so Homey receives the first known state immediately after add.
- Kept host/port as mutable store fields for new devices, while preserving fallback support for older devices that already have host/port in `data`.

## Review guide

Suggested review order:

1. `drivers/airco/capabilities.ts`
2. `drivers/airco/discovery-targets.ts`
3. pairing path in `drivers/airco/driver.ts`
4. runtime path in `drivers/airco/device.ts`
5. pairing UI/locales

## Related reports

Auto-closes the reports that match this PR's main discovery/runtime reliability path:

- Fixes #9: multi-device discovery/pairing can miss additional AC units.
- Fixes #13: devices become unreachable and may need repair/restart.
- Fixes #18: devices can become unavailable after running for a while.

Related to reports that may still need device-specific confirmation or credentials/token follow-up:

- Related to [#1 - Not possible to add devices](https://github.com/mteutelink/nl.intyme.midea/issues/1): discovery does not find devices reliably and users need a less technical manual add path.
- Related to [#5 - devices are in homey but not reachable](https://github.com/mteutelink/nl.intyme.midea/issues/5): devices can be present in Homey but still fail at runtime.
- Related to [#17 - Midea Extreme - MSAG-18HRN1 Homey problem](https://github.com/mteutelink/nl.intyme.midea/issues/17): token/key pairing can fail on some Midea-compatible setups.

## Validation

Ran locally against this branch:

- `bun run build`
- `bun run lint`
- `bunx --bun homey app build`

Also validated locally on a Homey Self-Hosted Server installation with two AC devices:

- direct LAN state polling
- control path requiring fresh state before `SetStateCommand`
- LAN session timeout recovery
- rediscovery/update of mutable host/port
- pairing output with non-empty initial `capabilitiesValues`
- no duplicate Homey identity for the same AC when host/port changes

The Homey build still emits existing future warnings about missing `titleFormatted` on some Flow cards; this PR does not change those Flow-card titles.

## Privacy / public PR notes

- No local network addresses, hostnames, databases, backups, or secrets are included.
- Local-only verification helpers are ignored and excluded from production build output.
- `package-lock.json` only contains root metadata churn from the local package manager; no dependency version changes are intended.

